### PR TITLE
Add lycoris-lora 1.9.0

### DIFF
--- a/requirements-pre.in
+++ b/requirements-pre.in
@@ -4,3 +4,6 @@ torchvision==0.15.2+cu118
 xformers==0.0.22
 lion-pytorch
 dadaptation
+
+# https://github.com/KohakuBlueleaf/LyCORIS
+lycoris-lora

--- a/requirements-pre.txt
+++ b/requirements-pre.txt
@@ -14,18 +14,34 @@ cmake==3.27.6
     # via triton
 dadaptation==3.1
     # via -r requirements-pre.in
+diffusers==0.21.4
+    # via lycoris-lora
 filelock==3.12.4
     # via
+    #   diffusers
+    #   huggingface-hub
     #   torch
+    #   transformers
     #   triton
+fsspec==2023.10.0
+    # via huggingface-hub
+huggingface-hub==0.17.3
+    # via
+    #   diffusers
+    #   tokenizers
+    #   transformers
 idna==3.4
     # via requests
+importlib-metadata==6.8.0
+    # via diffusers
 jinja2==3.1.2
     # via torch
 lion-pytorch==0.1.2
     # via -r requirements-pre.in
 lit==17.0.2
     # via triton
+lycoris-lora==1.9.0
+    # via -r requirements-pre.in
 markupsafe==2.1.3
     # via jinja2
 mpmath==1.3.0
@@ -34,28 +50,66 @@ networkx==3.1
     # via torch
 numpy==1.26.0
     # via
+    #   diffusers
     #   torchvision
+    #   transformers
     #   xformers
+packaging==23.2
+    # via
+    #   huggingface-hub
+    #   transformers
 pillow==10.0.1
-    # via torchvision
+    # via
+    #   diffusers
+    #   torchvision
+pyyaml==6.0.1
+    # via
+    #   huggingface-hub
+    #   transformers
+regex==2023.10.3
+    # via
+    #   diffusers
+    #   transformers
 requests==2.31.0
-    # via torchvision
+    # via
+    #   diffusers
+    #   huggingface-hub
+    #   torchvision
+    #   transformers
+safetensors==0.4.0
+    # via
+    #   diffusers
+    #   lycoris-lora
+    #   transformers
 sympy==1.12
     # via torch
+tokenizers==0.14.1
+    # via transformers
 torch==2.0.1+cu118
     # via
     #   -r requirements-pre.in
     #   lion-pytorch
+    #   lycoris-lora
     #   torchvision
     #   triton
     #   xformers
 torchvision==0.15.2+cu118
     # via -r requirements-pre.in
+tqdm==4.66.1
+    # via
+    #   huggingface-hub
+    #   transformers
+transformers==4.35.0
+    # via lycoris-lora
 triton==2.0.0
     # via torch
 typing-extensions==4.8.0
-    # via torch
+    # via
+    #   huggingface-hub
+    #   torch
 urllib3==2.0.6
     # via requests
 xformers==0.0.22
     # via -r requirements-pre.in
+zipp==3.17.0
+    # via importlib-metadata


### PR DESCRIPTION
Add Python library `lycoris_lora` to train LyCORIS.

- PyPI: [lycoris-lora](https://pypi.org/project/lycoris-lora/)
- GitHub: [KohakuBlueleaf/LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS)

Related issue

- close #8 