### PR TITLE
doc: Docker Engine >= 27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This patch is applied. Technical validity is not guaranteed.
 
 ## Requirements
 
-- Docker Engine >= 23.0
+- Docker Engine >= 27.0
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 
 ## Usage


### PR DESCRIPTION
古いもので動かなくても対応するリソースがないので、新しいものを要求するようにする。