### PR TITLE
ci: test published sd-scripts Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -137,9 +134,16 @@ jobs:
 
       - name: Run upstream sd-scripts pytest release tests
         run: |-
-          docker run --rm --user root --entrypoint bash sd-scripts:release-test -lc '
+          docker run --rm --user root --entrypoint bash \
+            -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
+            -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
+            sd-scripts:release-test -lc '
             set -euo pipefail
-            uv pip install pytest
+            cd /tmp/release-test-project
+            uv export --frozen --only-group dev --no-emit-project --format requirements.txt \
+              --output-file /tmp/release-test-requirements.txt
+            uv pip install --requirement /tmp/release-test-requirements.txt
+            cd /opt/sd-scripts
             pytest -q \
               tests/test_custom_offloading_utils.py \
               tests/test_expand_unet_to_inpainting.py \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,7 +64,7 @@ jobs:
     needs:
       - version
       - test-docker
-    if: ${{ github.event_name == 'push' && needs.version.outputs.release_mode != 'edge' }}
+    if: ${{ needs.version.outputs.release_mode != 'edge' }}
 
     runs-on: ubuntu-slim
 
@@ -86,9 +85,6 @@ jobs:
           generateReleaseNotes: true
 
   test-docker:
-    needs:
-      - version
-
     runs-on: ubuntu-latest
 
     permissions:
@@ -167,7 +163,7 @@ jobs:
       - version
       - test-docker
       - release
-    if: ${{ github.event_name == 'push' && always() && needs.version.result == 'success' && needs.test-docker.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
+    if: ${{ always() && needs.version.result == 'success' && needs.test-docker.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,9 +140,7 @@ jobs:
             sd-scripts:release-test -lc '
             set -euo pipefail
             cd /tmp/release-test-project
-            uv export --frozen --only-group dev --no-emit-project --format requirements.txt \
-              --output-file /tmp/release-test-requirements.txt
-            uv pip install --requirement /tmp/release-test-requirements.txt
+            uv sync --frozen --only-group dev --inexact --no-install-project
             cd /opt/sd-scripts
             pytest -q \
               tests/test_custom_offloading_utils.py \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,10 @@ jobs:
     needs:
       - version
       - release
+    # Keep the original release flow: create the GitHub release first, then
+    # publish Docker tags for that commit. Edge builds intentionally skip the
+    # release job, so the Docker publish path must accept either success or
+    # skipped here.
     if: ${{ always() && needs.version.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
 
     runs-on: ubuntu-latest
@@ -226,6 +230,9 @@ jobs:
       - name: Pull built Docker image
         id: image
         run: |-
+          # Test the image tag that build-docker just pushed, not a second local
+          # build. Latest releases are immutable version tags; edge builds reuse
+          # the moving edge tag because VERSION either already exists or is 0.0.0.
           if [[ "${{ needs.version.outputs.release_mode }}" == "latest" ]]; then
             image="${{ env.GHCR_IMAGE_NAME }}:${{ needs.version.outputs.tag }}"
           else
@@ -237,6 +244,9 @@ jobs:
 
       - name: Run upstream sd-scripts pytest release tests
         run: |-
+          # Mount the repository read-only so the tested image supplies
+          # /opt/sd-scripts, while this repository supplies the locked pytest
+          # dev dependency group and the shared release-test script.
           docker run --rm --user root --entrypoint bash \
             -v "${PWD}:/tmp/release-test-project:ro" \
             "${{ steps.image.outputs.image }}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,10 +244,4 @@ jobs:
 
       - name: Run upstream sd-scripts pytest release tests
         run: |-
-          # Mount the repository read-only so the tested image supplies
-          # /opt/sd-scripts, while this repository supplies the locked pytest
-          # dev dependency group and the shared release-test script.
-          docker run --rm --user root --entrypoint bash \
-            -v "${PWD}:/tmp/release-test-project:ro" \
-            "${{ steps.image.outputs.image }}" \
-            /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh
+          scripts/run-sd-scripts-release-tests.sh --image "${{ steps.image.outputs.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Build
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +67,8 @@ jobs:
   release:
     needs:
       - version
-    if: ${{ needs.version.outputs.release_mode != 'edge' }}
+      - test-docker
+    if: ${{ github.event_name == 'push' && needs.version.outputs.release_mode != 'edge' }}
 
     runs-on: ubuntu-slim
 
@@ -83,11 +88,85 @@ jobs:
           makeLatest: ${{ needs.version.outputs.release_mode == 'latest' }}
           generateReleaseNotes: true
 
+  test-docker:
+    needs:
+      - version
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Free disk space
+        run: |-
+          # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+          sudo rm -rf \
+            "$AGENT_TOOLSDIRECTORY" \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+          df -h /
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build release test image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          load: true
+          push: false
+          tags: sd-scripts:release-test
+          cache-from: type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:edge-buildcache
+
+      - name: Run upstream sd-scripts pytest release tests
+        run: |-
+          docker run --rm --user root --entrypoint bash sd-scripts:release-test -lc '
+            set -euo pipefail
+            uv pip install pytest
+            pytest -q \
+              tests/test_custom_offloading_utils.py \
+              tests/test_expand_unet_to_inpainting.py \
+              tests/test_fine_tune.py \
+              tests/test_flux_train.py \
+              tests/test_flux_train_network.py \
+              tests/test_lumina_train_network.py \
+              tests/test_mask_generator.py \
+              tests/test_sd3_train.py \
+              tests/test_sd3_train_network.py \
+              tests/test_sdxl_train.py \
+              tests/test_sdxl_train_leco.py \
+              tests/test_sdxl_train_network.py \
+              tests/test_train.py \
+              tests/test_train_leco.py \
+              tests/test_train_network.py \
+              tests/test_train_textual_inversion.py \
+              tests/test_validation.py \
+              tests/library
+          '
+
   build-docker:
     needs:
       - version
+      - test-docker
       - release
-    if: ${{ always() && needs.version.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
+    if: ${{ github.event_name == 'push' && always() && needs.version.result == 'success' && needs.test-docker.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,12 @@ jobs:
             release_mode=latest
           fi
 
-          echo "tag_exists=${tag_exists}" >> "$GITHUB_OUTPUT"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "release_mode=${release_mode}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag_exists=${tag_exists}"
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "release_mode=${release_mode}"
+          } >> "$GITHUB_OUTPUT"
 
   release:
     needs:
@@ -236,29 +238,6 @@ jobs:
       - name: Run upstream sd-scripts pytest release tests
         run: |-
           docker run --rm --user root --entrypoint bash \
-            -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
-            -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
-            "${{ steps.image.outputs.image }}" -lc '
-            set -euo pipefail
-            uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
-            cd /opt/sd-scripts
-            pytest -q \
-              tests/test_custom_offloading_utils.py \
-              tests/test_expand_unet_to_inpainting.py \
-              tests/test_fine_tune.py \
-              tests/test_flux_train.py \
-              tests/test_flux_train_network.py \
-              tests/test_lumina_train_network.py \
-              tests/test_mask_generator.py \
-              tests/test_sd3_train.py \
-              tests/test_sd3_train_network.py \
-              tests/test_sdxl_train.py \
-              tests/test_sdxl_train_leco.py \
-              tests/test_sdxl_train_network.py \
-              tests/test_train.py \
-              tests/test_train_leco.py \
-              tests/test_train_network.py \
-              tests/test_train_textual_inversion.py \
-              tests/test_validation.py \
-              tests/library
-          '
+            -v "${PWD}:/tmp/release-test-project:ro" \
+            "${{ steps.image.outputs.image }}" \
+            /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,10 +85,15 @@ jobs:
           generateReleaseNotes: true
 
   test-docker:
+    needs:
+      - version
+      - build-docker
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
+      packages: read
 
     steps:
       - name: Free disk space
@@ -113,27 +118,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      - name: Build release test image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      - name: Login to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          load: true
-          push: false
-          tags: sd-scripts:release-test
-          cache-from: type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:edge-buildcache
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull built Docker image
+        id: image
+        run: |-
+          if [[ "${{ needs.version.outputs.release_mode }}" == "latest" ]]; then
+            image="${{ env.GHCR_IMAGE_NAME }}:${{ needs.version.outputs.tag }}"
+          else
+            image="${{ env.GHCR_IMAGE_NAME }}:edge"
+          fi
+
+          docker pull "${image}"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
 
       - name: Run upstream sd-scripts pytest release tests
         run: |-
           docker run --rm --user root --entrypoint bash \
             -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
             -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
-            sd-scripts:release-test -lc '
+            "${{ steps.image.outputs.image }}" -lc '
             set -euo pipefail
             uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
             cd /opt/sd-scripts
@@ -161,9 +170,6 @@ jobs:
   build-docker:
     needs:
       - version
-      - test-docker
-      - release
-    if: ${{ always() && needs.version.result == 'success' && needs.test-docker.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,89 +83,6 @@ jobs:
           makeLatest: ${{ needs.version.outputs.release_mode == 'latest' }}
           generateReleaseNotes: true
 
-  test-docker:
-    needs:
-      - version
-      - build-docker
-
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Free disk space
-        run: |-
-          # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
-          sudo rm -rf \
-            "$AGENT_TOOLSDIRECTORY" \
-            /opt/google/chrome \
-            /opt/microsoft/msedge \
-            /opt/microsoft/powershell \
-            /opt/pipx \
-            /usr/lib/mono \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/lib/node_modules \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/share/dotnet \
-            /usr/share/swift
-          df -h /
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull built Docker image
-        id: image
-        run: |-
-          if [[ "${{ needs.version.outputs.release_mode }}" == "latest" ]]; then
-            image="${{ env.GHCR_IMAGE_NAME }}:${{ needs.version.outputs.tag }}"
-          else
-            image="${{ env.GHCR_IMAGE_NAME }}:edge"
-          fi
-
-          docker pull "${image}"
-          echo "image=${image}" >> "$GITHUB_OUTPUT"
-
-      - name: Run upstream sd-scripts pytest release tests
-        run: |-
-          docker run --rm --user root --entrypoint bash \
-            -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
-            -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
-            "${{ steps.image.outputs.image }}" -lc '
-            set -euo pipefail
-            uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
-            cd /opt/sd-scripts
-            pytest -q \
-              tests/test_custom_offloading_utils.py \
-              tests/test_expand_unet_to_inpainting.py \
-              tests/test_fine_tune.py \
-              tests/test_flux_train.py \
-              tests/test_flux_train_network.py \
-              tests/test_lumina_train_network.py \
-              tests/test_mask_generator.py \
-              tests/test_sd3_train.py \
-              tests/test_sd3_train_network.py \
-              tests/test_sdxl_train.py \
-              tests/test_sdxl_train_leco.py \
-              tests/test_sdxl_train_network.py \
-              tests/test_train.py \
-              tests/test_train_leco.py \
-              tests/test_train_network.py \
-              tests/test_train_textual_inversion.py \
-              tests/test_validation.py \
-              tests/library
-          '
-
   build-docker:
     needs:
       - version
@@ -262,3 +179,86 @@ jobs:
           cache-to: ${{ steps.cache.outputs.cache_to }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+
+  test-docker:
+    needs:
+      - version
+      - build-docker
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Free disk space
+        run: |-
+          # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+          sudo rm -rf \
+            "$AGENT_TOOLSDIRECTORY" \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+          df -h /
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull built Docker image
+        id: image
+        run: |-
+          if [[ "${{ needs.version.outputs.release_mode }}" == "latest" ]]; then
+            image="${{ env.GHCR_IMAGE_NAME }}:${{ needs.version.outputs.tag }}"
+          else
+            image="${{ env.GHCR_IMAGE_NAME }}:edge"
+          fi
+
+          docker pull "${image}"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+
+      - name: Run upstream sd-scripts pytest release tests
+        run: |-
+          docker run --rm --user root --entrypoint bash \
+            -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
+            -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
+            "${{ steps.image.outputs.image }}" -lc '
+            set -euo pipefail
+            uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
+            cd /opt/sd-scripts
+            pytest -q \
+              tests/test_custom_offloading_utils.py \
+              tests/test_expand_unet_to_inpainting.py \
+              tests/test_fine_tune.py \
+              tests/test_flux_train.py \
+              tests/test_flux_train_network.py \
+              tests/test_lumina_train_network.py \
+              tests/test_mask_generator.py \
+              tests/test_sd3_train.py \
+              tests/test_sd3_train_network.py \
+              tests/test_sdxl_train.py \
+              tests/test_sdxl_train_leco.py \
+              tests/test_sdxl_train_network.py \
+              tests/test_train.py \
+              tests/test_train_leco.py \
+              tests/test_train_network.py \
+              tests/test_train_textual_inversion.py \
+              tests/test_validation.py \
+              tests/library
+          '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
   release:
     needs:
       - version
-      - test-docker
     if: ${{ needs.version.outputs.release_mode != 'edge' }}
 
     runs-on: ubuntu-slim
@@ -170,6 +169,8 @@ jobs:
   build-docker:
     needs:
       - version
+      - release
+    if: ${{ always() && needs.version.result == 'success' && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,7 @@ jobs:
             -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
             sd-scripts:release-test -lc '
             set -euo pipefail
-            cd /tmp/release-test-project
-            uv sync --frozen --only-group dev --inexact --no-install-project
+            uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
             cd /opt/sd-scripts
             pytest -q \
               tests/test_custom_offloading_utils.py \

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -330,32 +330,9 @@ the same lightweight upstream pytest set that CI uses:
 
 ```shell
 docker run --rm --user root --entrypoint bash \
-  -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
-  -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
-  sd-scripts:update-test -lc '
-  set -euo pipefail
-  uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
-  cd /opt/sd-scripts
-  pytest -q \
-    tests/test_custom_offloading_utils.py \
-    tests/test_expand_unet_to_inpainting.py \
-    tests/test_fine_tune.py \
-    tests/test_flux_train.py \
-    tests/test_flux_train_network.py \
-    tests/test_lumina_train_network.py \
-    tests/test_mask_generator.py \
-    tests/test_sd3_train.py \
-    tests/test_sd3_train_network.py \
-    tests/test_sdxl_train.py \
-    tests/test_sdxl_train_leco.py \
-    tests/test_sdxl_train_network.py \
-    tests/test_train.py \
-    tests/test_train_leco.py \
-    tests/test_train_network.py \
-    tests/test_train_textual_inversion.py \
-    tests/test_validation.py \
-    tests/library
-'
+  -v "${PWD}:/tmp/release-test-project:ro" \
+  sd-scripts:update-test \
+  /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh
 ```
 
 This set intentionally excludes upstream tests and scripts that need model

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -321,7 +321,63 @@ For a release that changes PyTorch, CUDA, xformers, or sd-scripts training
 behavior, run at least one small project-specific training or captioning
 workflow before merging when practical.
 
-## 11. Review And Record The Change
+## 11. Run Upstream Release Tests
+
+The Docker image includes the selected upstream sd-scripts checkout under
+`/opt/sd-scripts`, including the upstream `tests/` directory. Install `pytest`
+temporarily in a disposable container and run the same lightweight upstream
+pytest set that CI uses:
+
+```shell
+docker run --rm --user root --entrypoint bash sd-scripts:update-test -lc '
+  set -euo pipefail
+  uv pip install pytest
+  pytest -q \
+    tests/test_custom_offloading_utils.py \
+    tests/test_expand_unet_to_inpainting.py \
+    tests/test_fine_tune.py \
+    tests/test_flux_train.py \
+    tests/test_flux_train_network.py \
+    tests/test_lumina_train_network.py \
+    tests/test_mask_generator.py \
+    tests/test_sd3_train.py \
+    tests/test_sd3_train_network.py \
+    tests/test_sdxl_train.py \
+    tests/test_sdxl_train_leco.py \
+    tests/test_sdxl_train_network.py \
+    tests/test_train.py \
+    tests/test_train_leco.py \
+    tests/test_train_network.py \
+    tests/test_train_textual_inversion.py \
+    tests/test_validation.py \
+    tests/library
+'
+```
+
+This set intentionally excludes upstream tests and scripts that need model
+checkpoints, local datasets, or dependencies this image does not bundle, such
+as `tests/test_optimizer.py` requiring `dadaptation`.
+
+When an NVIDIA GPU and compatible test checkpoint are available, also run at
+least one upstream inpainting training smoke test. The scripts generate
+synthetic image data automatically when `--data` is omitted:
+
+```shell
+docker run --rm --gpus all --entrypoint bash \
+  -v /path/to/models:/models:ro \
+  sd-scripts:update-test \
+  tests/run_sd15_inpainting_test.sh --mode ft --model /models/sd15-inpainting.safetensors --steps 1
+
+docker run --rm --gpus all --entrypoint bash \
+  -v /path/to/models:/models:ro \
+  sd-scripts:update-test \
+  tests/run_sdxl_inpainting_test.sh --mode ft --model /models/sdxl-base-or-inpainting.safetensors --steps 1
+```
+
+If GPU or checkpoint coverage is skipped, record the exact reason in the pull
+request.
+
+## 12. Review And Record The Change
 
 Review the diff:
 
@@ -340,9 +396,12 @@ Confirm:
 - Apt package versions were checked inside the selected CUDA image.
 - `uv.lock` resolves the selected PyTorch CUDA index.
 - Local extras are intentionally kept, updated, or removed.
+- Upstream sd-scripts pytest release tests passed in the built image.
+- Upstream inpainting shell tests were run, or GPU/checkpoint coverage was
+  explicitly skipped.
 - Verification commands and any skipped GPU tests are documented in the PR.
 
-## 12. Open The Pull Request
+## 13. Open The Pull Request
 
 Create a focused commit, push the branch, and open a pull request.
 
@@ -351,7 +410,9 @@ The PR body should include:
 - The selected sd-scripts version and commit SHA.
 - Any CUDA, Ubuntu, PyTorch, xformers, or local-extra dependency changes.
 - The checks run locally.
-- Whether runtime GPU training was tested or skipped.
+- Whether upstream pytest release tests passed in the built image.
+- Whether runtime GPU and upstream inpainting training tests were tested or
+  skipped.
 
 Do not update `VERSION` as part of the sd-scripts update unless the same PR is
 also intentionally publishing a Docker image release. Follow the README release

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -329,10 +329,7 @@ uv-managed dev test dependencies temporarily in a disposable container and run
 the same lightweight upstream pytest set that CI uses:
 
 ```shell
-docker run --rm --user root --entrypoint bash \
-  -v "${PWD}:/tmp/release-test-project:ro" \
-  sd-scripts:update-test \
-  /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh
+scripts/run-sd-scripts-release-tests.sh --image sd-scripts:update-test
 ```
 
 This set intentionally excludes upstream tests and scripts that need model

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -335,9 +335,7 @@ docker run --rm --user root --entrypoint bash \
   sd-scripts:update-test -lc '
   set -euo pipefail
   cd /tmp/release-test-project
-  uv export --frozen --only-group dev --no-emit-project --format requirements.txt \
-    --output-file /tmp/release-test-requirements.txt
-  uv pip install --requirement /tmp/release-test-requirements.txt
+  uv sync --frozen --only-group dev --inexact --no-install-project
   cd /opt/sd-scripts
   pytest -q \
     tests/test_custom_offloading_utils.py \

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -324,14 +324,21 @@ workflow before merging when practical.
 ## 11. Run Upstream Release Tests
 
 The Docker image includes the selected upstream sd-scripts checkout under
-`/opt/sd-scripts`, including the upstream `tests/` directory. Install `pytest`
-temporarily in a disposable container and run the same lightweight upstream
-pytest set that CI uses:
+`/opt/sd-scripts`, including the upstream `tests/` directory. Install the
+uv-managed dev test dependencies temporarily in a disposable container and run
+the same lightweight upstream pytest set that CI uses:
 
 ```shell
-docker run --rm --user root --entrypoint bash sd-scripts:update-test -lc '
+docker run --rm --user root --entrypoint bash \
+  -v "${PWD}/pyproject.toml:/tmp/release-test-project/pyproject.toml:ro" \
+  -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
+  sd-scripts:update-test -lc '
   set -euo pipefail
-  uv pip install pytest
+  cd /tmp/release-test-project
+  uv export --frozen --only-group dev --no-emit-project --format requirements.txt \
+    --output-file /tmp/release-test-requirements.txt
+  uv pip install --requirement /tmp/release-test-requirements.txt
+  cd /opt/sd-scripts
   pytest -q \
     tests/test_custom_offloading_utils.py \
     tests/test_expand_unet_to_inpainting.py \

--- a/docs/update-sd-scripts.md
+++ b/docs/update-sd-scripts.md
@@ -334,8 +334,7 @@ docker run --rm --user root --entrypoint bash \
   -v "${PWD}/uv.lock:/tmp/release-test-project/uv.lock:ro" \
   sd-scripts:update-test -lc '
   set -euo pipefail
-  cd /tmp/release-test-project
-  uv sync --frozen --only-group dev --inexact --no-install-project
+  uv sync --project /tmp/release-test-project --frozen --only-group dev --inexact --no-install-project
   cd /opt/sd-scripts
   pytest -q \
     tests/test_custom_offloading_utils.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,8 @@ explicit = true
 torch = { index = "pytorch-cu129" }
 torchvision = { index = "pytorch-cu129" }
 xformers = { index = "pytorch-cu129" }
+
+[dependency-groups]
+dev = [
+  "pytest==9.0.3",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ xformers = { index = "pytorch-cu129" }
 
 [dependency-groups]
 dev = [
-  "pytest==9.0.3",
+  "pytest>=9.0.3",
 ]

--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -5,7 +5,6 @@ usage() {
     cat <<'USAGE'
 Usage:
   scripts/run-sd-scripts-release-tests.sh --image IMAGE
-  scripts/run-sd-scripts-release-tests.sh
 
 Options:
   --image IMAGE     Run the release tests inside the given Docker image.
@@ -36,25 +35,27 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -n "${image}" ]]; then
-    script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-    repo_dir="$(cd -- "${script_dir}/.." && pwd)"
-
-    # Run the same checked-in script inside the image under test. The
-    # repository mount is read-only because the image should provide the
-    # sd-scripts checkout, while this repository only provides locked test
-    # tooling and the selected pytest target list.
-    docker run --rm --user root --entrypoint bash \
-        -v "${repo_dir}:/tmp/release-test-project:ro" \
-        "${image}" \
-        /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh
-    exit 0
+if [[ -z "${image}" ]]; then
+    usage >&2
+    exit 1
 fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd -- "${script_dir}/.." && pwd)"
+
+# Mount this repository read-only because the image should provide the
+# sd-scripts checkout under /opt/sd-scripts. The repository mount only provides
+# the uv lock and the selected pytest target list for the release gate.
+docker run --rm --user root --entrypoint bash \
+    -v "${repo_dir}:/tmp/release-test-project:ro" \
+    "${image}" \
+    -lc '
+set -euo pipefail
 
 project_dir="${PROJECT_DIR:-/tmp/release-test-project}"
 sd_scripts_dir="${SD_SCRIPTS_DIR:-/opt/sd-scripts}"
 
-# Keep pytest under this repository's uv lock instead of installing an
+# Keep pytest under this repository'\''s uv lock instead of installing an
 # unpinned tool in CI. The Docker image is built with --no-dev, so only the
 # dev group is added at test time. --inexact preserves the already-built
 # runtime environment in /opt/python-venv instead of pruning sd-scripts
@@ -87,3 +88,4 @@ pytest -q \
     tests/test_train_textual_inversion.py \
     tests/test_validation.py \
     tests/library
+'

--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -4,10 +4,20 @@ set -euo pipefail
 project_dir="${PROJECT_DIR:-/tmp/release-test-project}"
 sd_scripts_dir="${SD_SCRIPTS_DIR:-/opt/sd-scripts}"
 
+# Keep pytest under this repository's uv lock instead of installing an
+# unpinned tool in CI. The Docker image is built with --no-dev, so only the
+# dev group is added at test time. --inexact preserves the already-built
+# runtime environment in /opt/python-venv instead of pruning sd-scripts
+# dependencies that are not part of the dev-only sync target.
 uv sync --project "${project_dir}" --frozen --only-group dev --inexact --no-install-project
 
 cd "${sd_scripts_dir}"
 
+# This list is the release gate for tests that can run inside the published
+# image without model checkpoints, local datasets, or extra dependencies that
+# the image intentionally does not bundle. Keep model-backed inpainting scripts
+# and dependency-expansion tests such as test_optimizer.py in the documented
+# manual/GPU validation path unless the image starts shipping their inputs.
 pytest -q \
     tests/test_custom_offloading_utils.py \
     tests/test_expand_unet_to_inpainting.py \

--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -1,6 +1,67 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/run-sd-scripts-release-tests.sh --image IMAGE
+  scripts/run-sd-scripts-release-tests.sh --in-container
+
+Options:
+  --image IMAGE     Run the release tests inside the given Docker image.
+  --in-container    Run the pytest release test body inside the container.
+USAGE
+}
+
+image=""
+in_container=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            image="${2:-}"
+            if [[ -z "${image}" ]]; then
+                echo "Error: --image requires a Docker image tag" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --in-container)
+            in_container=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "${image}" ]]; then
+    script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    repo_dir="$(cd -- "${script_dir}/.." && pwd)"
+
+    # Run the same checked-in script inside the image under test. The
+    # repository mount is read-only because the image should provide the
+    # sd-scripts checkout, while this repository only provides locked test
+    # tooling and the selected pytest target list.
+    docker run --rm --user root --entrypoint bash \
+        -v "${repo_dir}:/tmp/release-test-project:ro" \
+        "${image}" \
+        /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh --in-container
+    exit 0
+fi
+
+if [[ "${in_container}" != "true" ]]; then
+    usage >&2
+    exit 1
+fi
+
 project_dir="${PROJECT_DIR:-/tmp/release-test-project}"
 sd_scripts_dir="${SD_SCRIPTS_DIR:-/opt/sd-scripts}"
 

--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_dir="${PROJECT_DIR:-/tmp/release-test-project}"
+sd_scripts_dir="${SD_SCRIPTS_DIR:-/opt/sd-scripts}"
+
+uv sync --project "${project_dir}" --frozen --only-group dev --inexact --no-install-project
+
+cd "${sd_scripts_dir}"
+
+pytest -q \
+    tests/test_custom_offloading_utils.py \
+    tests/test_expand_unet_to_inpainting.py \
+    tests/test_fine_tune.py \
+    tests/test_flux_train.py \
+    tests/test_flux_train_network.py \
+    tests/test_lumina_train_network.py \
+    tests/test_mask_generator.py \
+    tests/test_sd3_train.py \
+    tests/test_sd3_train_network.py \
+    tests/test_sdxl_train.py \
+    tests/test_sdxl_train_leco.py \
+    tests/test_sdxl_train_network.py \
+    tests/test_train.py \
+    tests/test_train_leco.py \
+    tests/test_train_network.py \
+    tests/test_train_textual_inversion.py \
+    tests/test_validation.py \
+    tests/library

--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -5,16 +5,14 @@ usage() {
     cat <<'USAGE'
 Usage:
   scripts/run-sd-scripts-release-tests.sh --image IMAGE
-  scripts/run-sd-scripts-release-tests.sh --in-container
+  scripts/run-sd-scripts-release-tests.sh
 
 Options:
   --image IMAGE     Run the release tests inside the given Docker image.
-  --in-container    Run the pytest release test body inside the container.
 USAGE
 }
 
 image=""
-in_container=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -25,10 +23,6 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             shift 2
-            ;;
-        --in-container)
-            in_container=true
-            shift
             ;;
         -h|--help)
             usage
@@ -53,13 +47,8 @@ if [[ -n "${image}" ]]; then
     docker run --rm --user root --entrypoint bash \
         -v "${repo_dir}:/tmp/release-test-project:ro" \
         "${image}" \
-        /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh --in-container
+        /tmp/release-test-project/scripts/run-sd-scripts-release-tests.sh
     exit 0
-fi
-
-if [[ "${in_container}" != "true" ]]; then
-    usage >&2
-    exit 1
 fi
 
 project_dir="${PROJECT_DIR:-/tmp/release-test-project}"

--- a/uv.lock
+++ b/uv.lock
@@ -951,7 +951,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.0.3" }]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "sentencepiece"

--- a/uv.lock
+++ b/uv.lock
@@ -144,6 +144,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fairscale"
 version = "0.4.13"
 source = { registry = "https://pypi.org/simple" }
@@ -287,6 +299,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -639,6 +660,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prodigy-plus-schedule-free"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -706,6 +736,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -862,6 +910,11 @@ dependencies = [
     { name = "xformers" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "accelerate", specifier = "==1.6.0" },
@@ -896,6 +949,9 @@ requires-dist = [
     { name = "voluptuous", specifier = "==0.15.2" },
     { name = "xformers", specifier = "==0.0.32.post2", index = "https://download.pytorch.org/whl/cu129" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = "==9.0.3" }]
 
 [[package]]
 name = "sentencepiece"
@@ -1011,6 +1067,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary
- Add a post-publish Docker release-test job that pulls the GHCR image produced by `build-docker` and runs selected upstream `kohya-ss/sd-scripts` pytest tests from the bundled `/opt/sd-scripts/tests` tree.
- Share the release-test Docker invocation and pytest target list through `scripts/run-sd-scripts-release-tests.sh`.
- Keep the release-test workflow on `main` pushes only; it does not run for pull requests.
- Manage `pytest` through the uv dev dependency group and `uv.lock`, then install those locked test dependencies temporarily in the disposable test container with `uv sync`.
- Keep the release flow ordered as GitHub release, Docker build/publish, then validation of the pushed Docker image.

## Testing
### Automated checks
- `bash -n scripts/run-sd-scripts-release-tests.sh`
- `shellcheck scripts/run-sd-scripts-release-tests.sh`
- `scripts/run-sd-scripts-release-tests.sh --help`
- `uv lock --check`
- `UV_PROJECT_ENVIRONMENT="$tmp_env" uv sync --project /home/aoi/workspaces/aiart_workspace/sd_scripts_docker/.agents/worktrees/integrate-sd-scripts-release-tests --frozen --only-group dev --inexact --no-install-project --dry-run`
- `actionlint -pyflakes=`
- `pinact run --check --min-age 7`
- `git diff --check`

### Not run
- Full `docker build` plus in-container upstream pytest release tests locally. The workflow now validates the GHCR image pushed by `build-docker`, which requires pulling/building the full CUDA image stack.
- GPU/checkpoint-backed upstream inpainting shell tests locally; no NVIDIA GPU or local test checkpoints were provided for this run.
