### PR TITLE
docs: document bundled sd-scripts license notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ Dockerfile for [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts).
 
 - [Updating sd-scripts](docs/update-sd-scripts.md)
 
+## License
+
+This repository's Dockerfile, documentation, and project-specific files are
+licensed under the MIT License. See [LICENSE](LICENSE).
+
+The published Docker image bundles
+[kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts) at the commit
+specified by `SD_SCRIPTS_VERSION` in the Dockerfile. sd-scripts is primarily
+licensed under the Apache License 2.0, with some portions under separate license
+terms. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and the upstream
+license information for details.
+
 ## Requirements
 
 - Ubuntu 24.04 or later

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,14 @@
+# Third-Party Notices
+
+This project builds Docker images that include third-party software.
+
+## kohya-ss/sd-scripts
+
+- Source: https://github.com/kohya-ss/sd-scripts
+- Bundled location in image: `/opt/sd-scripts`
+- Version: see `SD_SCRIPTS_VERSION` in `Dockerfile`
+- License: primarily Apache License 2.0, with some portions under separate
+  terms as documented upstream
+
+The image includes the selected upstream checkout, including the license files
+that are present in that checkout.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds a README license section that separates this repository's MIT-licensed project files from the bundled upstream `kohya-ss/sd-scripts` checkout.
- Adds `THIRD_PARTY_NOTICES.md` with the upstream source, bundled image location, version pointer, and license summary.

## Related Issues

None

## Notes for reviewers

### AI disclosure

Codex drafted the documentation text and checked the resulting diff for scope and Markdown whitespace issues.

## Testing

### Automated checks

- `git diff --check origin/main..HEAD`

### AI-assisted inspections

- Request: Review the documentation wording for clear license scope separation.
  - AI-assisted result: The README and notice file distinguish repository-owned MIT files from bundled upstream sd-scripts license terms without changing project behavior.
