### PR TITLE
ci: run Docker tests after edge builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,11 +126,11 @@ jobs:
 
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             ${{ env.IMAGE_NAME }}
@@ -161,20 +161,20 @@ jobs:
           fi
 
       - name: Login to ghcr.io
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Deploy Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -190,6 +190,7 @@ jobs:
     needs:
       - version
       - build-docker
+    if: ${{ always() && needs.version.result == 'success' && needs.build-docker.result == 'success' }}
 
     runs-on: ubuntu-latest
 
@@ -221,7 +222,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to ghcr.io
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add an explicit `test-docker` job condition so Docker release tests still run
  after edge builds where the `release` job is intentionally skipped.
- Run `pinact run --update --min-age 7` and refresh Docker action pins:
  - `docker/setup-buildx-action` v3.12.0 to v4.0.0
  - `docker/metadata-action` v5.10.0 to v6.0.0
  - `docker/login-action` v3.7.0 to v4.1.0
  - `docker/build-push-action` v6.18.0 to v7.1.0

## Related Issues

None

## Notes for reviewers

The latest `main` edge build published the Docker image, but `test-docker` was
skipped because it did not have an `always()` condition like `build-docker`.
This PR keeps `test-docker` gated on successful `version` and `build-docker`
jobs while allowing it to run when the unrelated `release` job is skipped for
edge builds.

### AI disclosure

Codex inspected the skipped main workflow run, updated the workflow condition,
ran pinact, performed local workflow checks, and drafted this pull request body.

## Testing

### Automated checks

- `actionlint -pyflakes=`
- `pinact run --update --min-age 7`
- `pinact run --check --min-age 7`
- `shellcheck` for shell files under `.github` and `scripts`
- `git diff --check`

### Supply-chain checks

- `pinact` selected full commit SHA pins and enforced a 7-day minimum age for
  updated GitHub Actions.
- Existing job permissions remain scoped per job: Docker publishing keeps
  `packages: write`, and Docker testing keeps `packages: read`.

### Not run

- GitHub Actions workflow execution. This PR should be validated by CI after it
  is opened.
