### PR TITLE
build(agent-skills): update APM-managed Skills

### DIFF
--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -26,15 +26,60 @@ Reference:
 
 1. Read the proposed message and, when available, the staged diff or
    commit diff it describes.
-2. Verify the first-line format, blank-line structure, body placement, and
+2. If the message is a GitHub pull request squash-merge commit, obtain the
+   canonical pull request title and number from GitHub. Require the first line
+   to be exactly `<pull request title> (#<pull request number>)`; do not rely
+   on a CLI default or accept a title that omits the number. Verify that this
+   exact candidate is passed as the merge command or API payload's subject,
+   rather than merely being prepared for comparison.
+3. Verify the first-line format, blank-line structure, body placement, and
    footer placement.
-3. Check that the type, optional scope, breaking-change marker, and short
+4. Check that the type, optional scope, breaking-change marker, and short
    description match the dominant intent of the change.
-4. Check that any body explains useful context, motivation, or impact instead
+5. Check that any body explains useful context, motivation, or impact instead
    of repeating the summary.
-5. Check required footer or trailer metadata, including `BREAKING CHANGE` and
+6. Check required footer or trailer metadata, including `BREAKING CHANGE` and
    AI agent `Co-authored-by:` trailers when applicable.
-6. Before an operation creates or rewrites a commit, validate the exact
+7. For a squash merge or other remote commit creation, determine the complete
+   applicable trailer set before writing the payload. Include the author of an
+   implemented issue and every material design or snippet contributor by
+   default, unless review marks the contributor not applicable. Retain the
+   GitHub account and exact attributable email used to resolve each human
+   trailer. Use the contributor's explicitly supplied GitHub-provided noreply
+   address by default. Use a Public Email only when the contributor explicitly
+   directs its use and the current GitHub user response exposes that exact
+   email; record the choice in the PR attribution block. Never synthesize a
+   noreply address from `@login` or an ID. If the exact email cannot be
+   resolved, retain `Needs identity` and stop rather than using a legacy
+   noreply form. Put every expected
+   `Co-authored-by:` line in the body file passed to the merge command, retain
+   each full `Token: value` line exactly once, and verify that same set in the
+   stored commit; do not treat a matching token with a different value as
+   preserved or permit an unapproved additional `Co-authored-by:` line.
+   When the associated PR has a proposed-attribution block, require every
+   payload trailer to match an `Included` exact line there, omit only `Not
+   applicable` candidates, and stop for `Needs identity` or unreviewed changes.
+   Any uncertainty about a candidate's contribution, applicability, GitHub
+   account, numeric ID, resolved trailer, or review status blocks the merge;
+   do not omit, guess, or downgrade that candidate to proceed.
+   Apply role precedence before selecting trailers: the PR creator is the
+   GitHub-squash primary Git author; a final-diff head-commit author,
+   implemented-issue author, or material design/snippet contributor is a
+   trailer candidate only when distinct from that primary author. Reviewers and
+   merge actors are not candidates from those roles alone. Preserve an
+   independently evidenced existing trailer even when another role would not
+   create one.
+   For a GitHub-hosted squash merge, expect GitHub to record the PR creator as
+   the primary Git author even when another person performs the merge. This is
+   platform metadata, not proof of contribution: the creator may be neither an
+   author nor co-author of the PR-head commits. Do not add either the PR creator
+   or merger as a `Co-authored-by:` solely because of those roles; retain the PR
+   `mergedBy` value separately and verify the stored GitHub author association
+   against the PR creator. If the creator is not a material contributor in the
+   final diff, mark the mismatch `Needs review` and stop until a maintainer
+   confirms the intentional attribution or selects another authorized
+   integration path.
+8. Before an operation creates or rewrites a commit, validate the exact
    candidate message that the operation will receive:
    - Build it from the same subject and body file or bytes that will be passed
      to the command or API.
@@ -52,8 +97,8 @@ Reference:
      as raw text, decode it, assert that the selected value is a `[string]`,
      and only then compare it with the candidate.
    - Do not perform the mutation until the candidate passes.
-7. Recommend the smallest correction that makes the message valid and accurate.
-8. If the diff contains multiple unrelated logical changes, recommend splitting
+9. Recommend the smallest correction that makes the message valid and accurate.
+10. If the diff contains multiple unrelated logical changes, recommend splitting
    the commit when practical.
 
 ## Format
@@ -146,6 +191,36 @@ For squash merges or other remote commit creation, do not trust an escaped
 command-line string or a post-merge inspection as the primary check. Validate
 the exact pre-mutation payload as described in the workflow, then verify the
 stored commit message after the operation as a secondary check.
+
+## Human Co-Author Trailers
+
+Treat the author of an implemented issue and a material design or snippet
+provider as co-authors by default. Keep their `@login` and numeric GitHub user
+ID in the PR attribution record, so a reviewer can mark a candidate `Not
+applicable` before merging. Use the contributor's explicitly supplied
+GitHub-provided noreply email by default; never synthesize a noreply address
+from their account ID and login. Use a Public Email only if the contributor
+explicitly directs that choice and GitHub currently exposes the exact address
+as public. An existing trailer is reusable only when its GitHub author
+association proves the same account. If no exact attributable email is
+available, retain `Needs identity` in the PR and stop rather than using a
+legacy noreply address or inventing one. Preserve every
+resolved line in the same candidate and
+stored-message checks used for AI co-authors.
+
+Reviewing or approving a PR alone is not material authorship. Before squash
+merging, inspect every PR-head commit and applied review suggestion. For each
+head-only commit whose material change remains in the final diff, carry its Git
+author and every existing `Co-authored-by:` identity into the expected trailer
+set unless the identity is already the PR creator's primary Git author.
+Preserve exact existing trailers where available; otherwise resolve the GitHub
+account under the human-trailer rule. GitHub records the suggestion provider and
+the person who applies an accepted suggestion as co-authors of its generated
+commit; carry both identities when that suggestion remains in the final diff,
+except an identity already represented as the PR creator's primary Git author.
+Record the source commit SHA or review URL in the PR attribution block. If a
+head commit, applied status, contributor set, or final-diff presence is
+uncertain, mark it `Needs review` and stop the merge.
 
 ## Type Selection
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -30,7 +30,12 @@ description:
 3. Before pushing, review the complete diff, recent commits, scope, and missing verification; run the final relevant
    checks.
 4. Push and create or update the PR with `pull-request-quality-check` when requested.
-5. Before a PR merge command performs local branch cleanup, check every active worktree. Do not let a hosted-PR CLI
+5. Before squash-merging a GitHub pull request, obtain its canonical title and number from GitHub. Explicitly set the
+   commit subject to `<pull request title> (#<pull request number>)`; do not rely on a CLI default or omit the number.
+   Pass that exact subject through the merge command's `--subject` option; constructing it only in a candidate file or
+   reading the PR title is insufficient. After merging, inspect the stored commit subject and confirm it still contains
+   that exact number suffix.
+6. Before a PR merge command performs local branch cleanup, check every active worktree. Do not let a hosted-PR CLI
    switch to the default branch or delete a branch when that branch is checked out by another worktree. Merge first;
    then perform any safe remote or local branch cleanup as a separate action.
 

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -2,7 +2,8 @@
 name: pull-request-quality-check
 description:
   Quality-check repository pull requests and PR-thread communication. Use when creating, updating, reviewing, or
-  validating PR titles, bodies, review comments, replies, or thread notes.
+  validating PR titles, bodies, review comments, replies, thread notes, or GitHub squash-merge attribution and
+  commit-message payloads.
 ---
 
 # Pull Request Quality Check
@@ -44,6 +45,51 @@ description:
 6. Write in English except for exact source material. Keep bodies reviewable, use bullets and backticks, avoid large
    diffs, state skipped verification, and use `prose-quality-check` or `security-check` for applicable prose or
    sensitive content.
+7. When a PR may produce a commit with human or AI co-author trailers, keep the proposed trailer set reviewable in
+   the PR body from creation through every update. Use the repository template's closest relevant section; if none
+   exists, append `## Proposed merge attribution` after the required template content. Include the issue author when
+   the PR implements their issue, and include a design or snippet provider whose material contribution is used; these
+   are default co-authors unless a reviewer marks the candidate `Not applicable`. For each human candidate, show their
+   canonical GitHub account as `@login` and immutable numeric GitHub user ID, the resolved exact `Co-authored-by:`
+   line, a concise non-private basis, and `Included`, `Needs identity`, `Needs review`, or `Not applicable` status.
+   For an AI candidate, show its exact trailer, basis, and status. State `None proposed` when the set is empty.
+
+   Apply role precedence before selecting trailers: the PR creator is the GitHub-squash primary Git author; a
+   final-diff head-commit author, implemented-issue author, or material design/snippet contributor is a trailer
+   candidate only when distinct from that primary author. Reviewers and merge actors are not candidates from those
+   roles alone. Preserve an independently evidenced existing trailer even when a person's other role would not create
+   one.
+
+   Resolve every human trailer from a GitHub account and an exact email that GitHub can attribute to that account. Use
+   the contributor's explicitly supplied GitHub-provided noreply address by default. Use a Public Email instead only
+   when that contributor explicitly directs its use for the trailer and the current GitHub user response exposes the
+   same email; record that choice in the PR attribution block. Never synthesize a noreply address from `@login` or an
+   ID. An existing head-commit trailer is reusable only when its GitHub author association proves the same account.
+   If the exact attributable email is unavailable, retain `Needs identity` and request it from the contributor rather
+   than inventing an address. On
+   a PR update, preserve every
+   candidate unless its basis changed; make additions, removals, account/ID changes, resolved-trailer changes, and
+   status changes reviewable rather than silently replacing the block. If any candidate's contribution, applicability,
+   account, numeric ID, resolved trailer, or review status is uncertain, use `Needs identity` or `Needs review` and
+   stop the merge until the uncertainty is resolved.
+   For a GitHub-hosted squash merge, expect GitHub to record the PR creator as the primary Git author. This is platform
+   metadata, not proof of material contribution: the creator can be neither an author nor co-author of the PR-head
+   commits. Do not add that person as `Co-authored-by:` merely because they opened the PR, and do not add the merge
+   actor merely for performing the merge. Record the PR creator and, after merge, the PR's `mergedBy` separately from
+   the trailer set. If the PR creator is not a material contributor in the final diff, mark that attribution mismatch
+   `Needs review` and stop before merging until a maintainer confirms the intentional GitHub-squash attribution or
+   selects another authorized integration path. Verify the stored commit's GitHub author association resolves to the
+   PR creator; record the platform committer as observed rather than assuming it is the merge actor.
+8. A review comment or approval alone does not create a co-author candidate. Before each squash merge, inspect all
+   commits reachable only from the PR head and the applied review suggestions. For each head-only commit whose material
+   change remains in the final PR diff, include its Git author and every existing `Co-authored-by:` identity in the
+   expected trailer set, unless that identity is already the PR creator's primary Git author. Preserve exact existing
+   trailers when available; otherwise resolve the contributor's GitHub account under the human-trailer rule above.
+   When GitHub created a commit by applying a review suggestion, include every suggestion provider and suggestion
+   applier that GitHub recorded as a co-author of that commit, provided the suggestion remains in the final PR diff,
+   except an identity already represented as the PR creator's primary Git author. Record each candidate's source commit
+   SHA or review URL in the PR attribution block. If a head commit, applied suggestion, contributor set, or final-diff
+   presence cannot be determined, mark it `Needs review` and stop the merge.
 
 ## Reviews, notes, and CLI safety
 
@@ -77,21 +123,50 @@ independent completion unit:
 
 Before `gh pr merge` creates a squash or merge commit:
 
-1. Resolve the exact PR head SHA and pass it with `--match-head-commit`.
-2. Write the merge body with real line breaks to a temporary file; do not pass
-   an escaped string containing literal `\n` sequences.
-3. Build the complete candidate commit message from the exact subject and body
-   file. Write those exact bytes to a candidate file and reject literal `\n`
+1. Resolve the pull request's canonical title, number, and head SHA from GitHub. Build the squash subject from that
+   metadata as `<pull request title> (#<pull request number>)`; do not rely on the CLI default or omit the number.
+   In PowerShell, use:
+
+    ```powershell
+    $pr = gh pr view <pr> --json number,title,headRefOid | ConvertFrom-Json
+    $subject = "$($pr.title) (#$($pr.number))"
+    if ($subject -notmatch '\(#[1-9]\d*\)$') { throw 'Missing PR number suffix.' }
+    ```
+
+2. Determine every applicable trailer before writing the merge body. Create an expected trailer set with the exact
+   `Token: value` line and attribution source for each entry. Include the author of an implemented issue and each
+   material design or snippet contributor by default, unless their PR-body candidate is marked `Not applicable`.
+   Resolve human trailers using the PR body's GitHub account and an exact attributable email; preserve each expected
+   `Co-authored-by:` trailer exactly once. When an AI agent materially contributed, include the repository-required
+   identity (for Codex, `Co-authored-by: Codex <noreply@openai.com>` unless a repository rule supplies another value).
+   If the PR has a `## Proposed merge attribution` block, reconcile it before merging: require every `Included` entry's
+   exact line to match the expected set, omit only `Not applicable` entries, and stop for `Needs identity`, a missing
+   candidate, or an unreviewed identity/trailer change. After merge, verify that each GitHub-account fallback trailer
+   is attributed to its expected account. Treat any uncertainty about a co-author candidate as a merge blocker, not as
+   a reason to omit, guess, or downgrade the candidate.
+3. Write the merge body with real line breaks to a temporary file; do not pass an escaped string containing literal
+   `\n` sequences. Put applicable trailers in its footer block, after one blank line from any body text and with no
+   blank lines between trailers.
+4. Build the complete candidate commit message from that exact `$subject` and the same body file. The merge command
+   must receive the same `$subject` through `--subject` and the same body file through `--body-file`; a candidate file
+   alone does not set the stored commit subject or preserve trailers.
+5. Write the exact candidate bytes to a file and reject literal `\n`
    or `\r\n` text. Pass the candidate file directly to
    `git interpret-trailers --parse`; do not pipe a shell string that may alter
-   line endings. Require each expected trailer exactly once.
-4. Before merging, test the stored-message verifier itself. Put the candidate
+   line endings. Require each expected trailer's full `Token: value` line exactly once and reject any additional
+   `Co-authored-by:` line that is not in the approved set.
+6. Before merging, test the stored-message verifier itself. Put the candidate
    message in a JSON fixture shaped like the commit API response, decode it
    through the same JSON parser planned for post-merge verification, and
    require `commit.message` to be one string equal to the candidate.
-5. Only after those validations succeed, pass the same body file with
-   `gh pr merge --body-file`.
-6. Verify the stored commit message and trailers after merge. Preserve the
+7. Only after those validations succeed, run the merge with the exact subject and resolved head SHA:
+
+    ```powershell
+    gh pr merge $pr.number --squash --subject $subject --match-head-commit $pr.headRefOid --body-file <body-file>
+    ```
+
+   Do not omit `--subject`, even if a CLI default currently appears to match the PR title.
+8. Verify the stored commit message and trailers after merge. Preserve the
    multiline value as one string:
    - Query the repository commit endpoint
      `repos/{owner}/{repo}/commits/{sha}`, whose response contains
@@ -106,4 +181,11 @@ Before `gh pr merge` creates a squash or merge commit:
    - Write the decoded `commit.message` string to a file, compare it with the
      candidate allowing at most terminal-newline normalization, and pass that
      file directly to `git interpret-trailers --parse`.
+   - Require each expected trailer's full `Token: value` line exactly once in
+     the parsed stored message; do not accept a matching trailer token with a
+     different value.
+   - Reject any additional stored `Co-authored-by:` line that is not in the
+     approved set.
+   - Require the stored first line to contain the exact `(#<pull request
+     number>)` suffix from the candidate subject.
    Treat this as a secondary check, not a substitute for pre-merge validation.

--- a/.agents/skills/pull-request-quality-check/agents/openai.yaml
+++ b/.agents/skills/pull-request-quality-check/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Pull Request Quality Check"
-  short_description: "Quality-check repository pull requests."
+  short_description: "Quality-check pull requests and squash merges."
   default_prompt: >-
-    Use $pull-request-quality-check to review this pull request title, body, reply, or review for repository
-    style, structure, verification notes, and required LLM disclosure.
+    Use $pull-request-quality-check to review this pull request or prepare a GitHub squash merge with verified
+    attribution and commit message.

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -74,6 +74,46 @@ generated outputs, packaging concerns,
 or areas that need extra attention for reasons other than AI assistance.
 -->
 
+### Proposed merge attribution
+
+<!--
+Keep every potential squash-merge co-author reviewable from PR creation through
+updates. Include the author of an implemented issue and every material design
+or snippet provider by default; a reviewer must explicitly mark a candidate
+"Not applicable" to exclude them.
+
+For a human candidate, record the public GitHub account and immutable numeric
+user ID, a non-private contribution basis, status, and the resolved trailer:
+- @login (GitHub user ID: 123)
+  - Resolved trailer: Co-authored-by: login <GitHub-provided-noreply@example.com>
+  - Basis: Implemented issue #123 / material design or snippet contribution.
+  - Status: Included / Needs identity / Needs review / Not applicable
+
+Do not add the PR creator or the person who merges merely because of those
+roles. GitHub squash merge records the PR creator as primary Git author, but
+that can differ from the material contributors. If the creator is not material
+to the final diff, mark this `Needs review` and do not merge until a maintainer
+confirms that attribution or selects another authorized integration path. A
+review comment or approval alone is not a candidate. Include every final-diff
+PR-head commit author and existing co-author trailer unless already the PR
+creator's primary Git author. If GitHub applied a review suggestion that remains
+in the final diff, include its suggestion provider and applier unless already
+the PR creator's primary Git author, and record the source commit SHA or review
+URL here.
+
+Use a contributor-supplied GitHub-provided noreply address for every human
+trailer by default; never synthesize one from @login or numeric ID. Use a Public
+Email only when the contributor explicitly directs that choice and GitHub
+currently exposes the exact address; record the choice here. An existing
+trailer is reusable only when its GitHub author association proves the same
+account. If any candidate's contribution, applicability, account, exact email,
+trailer, or status is uncertain, use Needs identity or Needs review and do not
+merge.
+Do not use a legacy LOGIN@users.noreply.github.com fallback. State "None
+proposed" if no candidates apply. Make all candidate/status/identity changes
+reviewable; do not silently remove or replace an entry.
+-->
+
 ### AI disclosure
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,7 @@ directly.
 
 ### Approved cooldown exception
 
-A maintainer explicitly approved adopting the current direct
-`aoirint/skills` commit
-`8a2bb13afb40cc31dbcd3280b74004834d428b4a` before its normal seven-day
-cooldown. This exception applies only to that direct dependency selection; it
+A maintainer may explicitly waive the normal seven-day wait for the latest
+`aoirint/skills` main commit. Record the waiver and exact full commit SHA in
+the pull request. That waiver applies only to the `aoirint/skills` commit; it
 does not waive review or cooldown requirements for any of its dependencies.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,6 @@ that are present in that checkout.
 - Source: [aoirint/skills](https://github.com/aoirint/skills), selected from
   `.apm/skills/`
 - Pinned commit:
-  [`8a2bb13afb40cc31dbcd3280b74004834d428b4a`](https://github.com/aoirint/skills/tree/8a2bb13afb40cc31dbcd3280b74004834d428b4a)
+  [`8c671f524fb5df6b9def895f8b60e9a359b07644`](https://github.com/aoirint/skills/tree/8c671f524fb5df6b9def895f8b60e9a359b07644)
 - Deployed paths: `.agents/skills/{changelog-workflow,code-quality-check,commit-message-quality-check,git-worktree-workflow,github-actions-quality-check,gitignore-workflow,issue-quality-check,prose-quality-check,pull-request-quality-check,release-note-workflow,security-check,skill-quality-check}/`
-- License: [MIT](https://github.com/aoirint/skills/blob/8a2bb13afb40cc31dbcd3280b74004834d428b4a/LICENSE)
+- License: [MIT](https://github.com/aoirint/skills/blob/8c671f524fb5df6b9def895f8b60e9a359b07644/LICENSE)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,12 +1,12 @@
 lockfile_version: '1'
-generated_at: '2026-07-25T16:40:09.434307+00:00'
+generated_at: '2026-07-26T00:25:17.733984+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: aoirint/skills
   name: skills
   host: github.com
-  resolved_commit: 8a2bb13afb40cc31dbcd3280b74004834d428b4a
-  resolved_ref: 8a2bb13afb40cc31dbcd3280b74004834d428b4a
+  resolved_commit: 8c671f524fb5df6b9def895f8b60e9a359b07644
+  resolved_ref: 8c671f524fb5df6b9def895f8b60e9a359b07644
   version: 0.0.0
   package_type: apm_package
   deployed_files:
@@ -72,10 +72,10 @@ dependencies:
     .agents/skills/code-quality-check/SKILL.md: sha256:30d64d4b25d9be96567f3e5f7106609e1a4d9a32b3c3d520d4b3aca459631990
     .agents/skills/code-quality-check/agents/openai.yaml: sha256:69a8a75579e3b47dc69a176417b97441adf81bc54984d3f6bc114e47a68bc9b3
     .agents/skills/commit-message-quality-check/README.md: sha256:c23949080d05f47cce728410ca3190225397aa41ac2015c6f02ee478ec412a24
-    .agents/skills/commit-message-quality-check/SKILL.md: sha256:23da198646b4b8588951d1744283b956a643c583d225c30914744b7ac997ec4b
+    .agents/skills/commit-message-quality-check/SKILL.md: sha256:db272bb7467bcb6a6c3d837dec60a34f7081c135fcd40a9e00cf4a84e29ffabe
     .agents/skills/commit-message-quality-check/agents/openai.yaml: sha256:faffd948a0989dcfc87dcd3b0580c4a7003d01ef436e66dab9f280df57de652c
     .agents/skills/git-worktree-workflow/README.md: sha256:fa6483b5919a01b84fa0d6ffcbaae20b84ed3807e18029e8807e61b0ee4f9de9
-    .agents/skills/git-worktree-workflow/SKILL.md: sha256:de1da6f326937196d7e0909d2fc57ed56d7db0dc2da7bc2990e3216ac29f3a7e
+    .agents/skills/git-worktree-workflow/SKILL.md: sha256:83ee54b3fd4c9620d4b70caae6701af40c34e9bf730cf6d69540f7f78d526aa4
     .agents/skills/git-worktree-workflow/agents/openai.yaml: sha256:3eb9da73e7a041e77d82f0d5c3a8c67e914575cff8651b71d077db30fe3da99a
     .agents/skills/github-actions-quality-check/README.md: sha256:a0767309bb84d170bc30070099a9f091b4c67cc00f790da88799685ab6bbaf5e
     .agents/skills/github-actions-quality-check/SKILL.md: sha256:1f2c556cda51ab47553bb7b2b9fbdcd4baa3709b2ba8d412c58397c6c5c5732d
@@ -91,9 +91,9 @@ dependencies:
     .agents/skills/prose-quality-check/SKILL.md: sha256:9ec45813d04382e04a3b504fd187e4151fc5198352564bd0bcb064f4eaf9a702
     .agents/skills/prose-quality-check/agents/openai.yaml: sha256:b83e0a5d151e6e20df6f7d97f268955c6abfd105d53820f6baad0de8403fc062
     .agents/skills/pull-request-quality-check/README.md: sha256:5c15de701adc508b9dd828846317f47b0f5b925c5a8842b6c32b4d9e3946e11f
-    .agents/skills/pull-request-quality-check/SKILL.md: sha256:3772297d3a34fddb651a0958be6e39ad3d415ee7f507739a85f88cd935480e46
-    .agents/skills/pull-request-quality-check/agents/openai.yaml: sha256:1ddb931336ca5ce10b9accf92787e36168c1c71a4b999bd85f130144e778bfa4
-    .agents/skills/pull-request-quality-check/references/fallback-pr-body.md: sha256:b381d75f9d1f525ce72f594b1cd8a8de37539bf29c5750c139bbd7113f606dfc
+    .agents/skills/pull-request-quality-check/SKILL.md: sha256:e79369ec883a152f51b40cc48f3e2664f07bcfea3af7d424fc0eef478b047ed5
+    .agents/skills/pull-request-quality-check/agents/openai.yaml: sha256:bfa37ecafec102caaa9ebe270428b423eae5451f9a0da1d6e02b419cde47f090
+    .agents/skills/pull-request-quality-check/references/fallback-pr-body.md: sha256:b98239e7d4cdddd8e267ab155f4e4c38fcc514526d9a32f13fcd5b21a1c07eb2
     .agents/skills/pull-request-quality-check/scripts/check_llm_disclosure.py: sha256:bc9c5cbd8efa77095eac42e53da714ed8dff86fa3b0e7870fc3e7eca1ca36e20
     .agents/skills/release-note-workflow/README.md: sha256:f13446e75a1c77495c4d55476ba8ca919aa3181e0864feb7a668a20a5cdf964b
     .agents/skills/release-note-workflow/SKILL.md: sha256:518296cb00d1ef181785ea8abd0150b9704b5cdd05a48fc0390284c548ef421c
@@ -107,7 +107,7 @@ dependencies:
     .agents/skills/skill-quality-check/SKILL.md: sha256:9d80bc143db3e00b0e20f6dccc895c22024a5f45faa6510e540fc8436372fe8d
     .agents/skills/skill-quality-check/agents/openai.yaml: sha256:dde624797ed750b9132f45378710cb6ea182a35705551b45d4b862bb6ce85805
     .agents/skills/skill-quality-check/references/authoring-best-practices.md: sha256:2d33bc3a032ebfbd3b2fa36e9160008a1ad256e22c6bb5a7d421ca1e04b2b5f3
-  content_hash: sha256:d62cfde91a170d1ddc2055eaf6a518e907d58b88314da92a2b831abc7dafcf40
+  content_hash: sha256:98c95516b2e461f9f8942fffcfb742376148768f6d6dae9739ec267fd01b9f86
   skill_subset:
   - changelog-workflow
   - code-quality-check
@@ -221,7 +221,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:23da198646b4b8588951d1744283b956a643c583d225c30914744b7ac997ec4b
+  content_hash: sha256:db272bb7467bcb6a6c3d837dec60a34f7081c135fcd40a9e00cf4a84e29ffabe
 - kind: project-relative
   target: codex
   value: .agents/skills/commit-message-quality-check/agents/openai.yaml
@@ -257,7 +257,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:de1da6f326937196d7e0909d2fc57ed56d7db0dc2da7bc2990e3216ac29f3a7e
+  content_hash: sha256:83ee54b3fd4c9620d4b70caae6701af40c34e9bf730cf6d69540f7f78d526aa4
 - kind: project-relative
   target: codex
   value: .agents/skills/git-worktree-workflow/agents/openai.yaml
@@ -446,7 +446,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:3772297d3a34fddb651a0958be6e39ad3d415ee7f507739a85f88cd935480e46
+  content_hash: sha256:e79369ec883a152f51b40cc48f3e2664f07bcfea3af7d424fc0eef478b047ed5
 - kind: project-relative
   target: codex
   value: .agents/skills/pull-request-quality-check/agents/openai.yaml
@@ -455,7 +455,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:1ddb931336ca5ce10b9accf92787e36168c1c71a4b999bd85f130144e778bfa4
+  content_hash: sha256:bfa37ecafec102caaa9ebe270428b423eae5451f9a0da1d6e02b419cde47f090
 - kind: project-relative
   target: codex
   value: .agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -464,7 +464,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:b381d75f9d1f525ce72f594b1cd8a8de37539bf29c5750c139bbd7113f606dfc
+  content_hash: sha256:b98239e7d4cdddd8e267ab155f4e4c38fcc514526d9a32f13fcd5b21a1c07eb2
 - kind: project-relative
   target: codex
   value: .agents/skills/pull-request-quality-check/scripts/check_llm_disclosure.py

--- a/apm.yml
+++ b/apm.yml
@@ -8,7 +8,7 @@ targets:
 dependencies:
   apm:
     - git: aoirint/skills
-      ref: 8a2bb13afb40cc31dbcd3280b74004834d428b4a
+      ref: 8c671f524fb5df6b9def895f8b60e9a359b07644
       skills:
         - changelog-workflow
         - code-quality-check


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Update the APM-managed `aoirint/skills` dependency to the latest main commit, `8c671f524fb5df6b9def895f8b60e9a359b07644`.
- Regenerate the APM lockfile and deployed Skills, including the updated merge-attribution and pull-request guidance.
- Record the maintainer-approved cooldown waiver policy without pinning it to a hash in repository guidance.

## Cooldown exception

The maintainer explicitly approved waiving the normal seven-day wait for this `aoirint/skills` update. The waiver applies only to the direct `aoirint/skills` commit above; its dependencies remain subject to their normal review and cooldown requirements.

## Testing

- `apm install --force --refresh`
- `apm install --frozen`
- `apm audit --ci`
- `git diff --check`

### AI-assisted inspections

Request: Review the pinned upstream source, MIT license, generated deployment hashes, and cooldown-exception scope.

AI-assisted result: The dependency is pinned to the reviewed full SHA, the upstream LICENSE remains MIT, the regenerated lockfile records the updated content hashes, and the frozen replay audit reports no deployment drift.

## Proposed merge attribution

- Resolved trailer: `Co-authored-by: Codex <noreply@openai.com>`
  - Basis: Codex prepared the dependency update, regeneration, validation, and pull request.
  - Status: Included
