### PR TITLE
docs: record APM CLI cooldown exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ directly.
 
 ### Approved cooldown exception
 
+Use APM CLI 0.26.0 for lock operations. Its normal seven-day cooldown was
+explicitly waived because it fixes virtual-package `config-consistency` audit
+failures. The waiver covers only the CLI release time gate.
+
 A maintainer may explicitly waive the normal seven-day wait for the latest
 `aoirint/skills` main commit. Record the waiver and exact full commit SHA in
 the pull request. That waiver applies only to the `aoirint/skills` commit; it


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Record the approved APM CLI 0.26.0 cooldown exception in `AGENTS.md`.
- Limit the waiver to the CLI release time gate for the virtual-package `config-consistency` audit fix.

## Testing

### Automated checks

- `git diff --check`

### AI-assisted inspections

- Request: Confirm the exception is under `Approved cooldown exception` and does not expand the `aoirint/skills` waiver.
  - AI-assisted result: The CLI and dependency exceptions are separate, and the CLI waiver is explicitly limited.
