### PR TITLE
fix(ci): align release tests with sd-scripts v0.11.1

### DIFF
--- a/scripts/run-sd-scripts-release-tests.sh
+++ b/scripts/run-sd-scripts-release-tests.sh
@@ -72,20 +72,10 @@ cd "${sd_scripts_dir}"
 pytest -q \
     tests/test_custom_offloading_utils.py \
     tests/test_expand_unet_to_inpainting.py \
-    tests/test_fine_tune.py \
-    tests/test_flux_train.py \
-    tests/test_flux_train_network.py \
     tests/test_lumina_train_network.py \
     tests/test_mask_generator.py \
-    tests/test_sd3_train.py \
-    tests/test_sd3_train_network.py \
-    tests/test_sdxl_train.py \
     tests/test_sdxl_train_leco.py \
-    tests/test_sdxl_train_network.py \
-    tests/test_train.py \
     tests/test_train_leco.py \
-    tests/test_train_network.py \
-    tests/test_train_textual_inversion.py \
     tests/test_validation.py \
     tests/library
 '


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Remove release-test paths deleted by sd-scripts v0.11.1.
- Retain the existing lightweight upstream pytest coverage and documented exclusions.

## Testing

- `shellcheck scripts/run-sd-scripts-release-tests.sh`
- Verified every selected pytest path against the v0.11.1 upstream tree.
- Edge-image test run was started locally, but the image pull did not complete before the tool session detached.

## Proposed merge attribution

- Resolved trailer: `Co-authored-by: Codex <noreply@openai.com>`
  - Basis: Codex diagnosed the CI failure and prepared the aligned test set.
  - Status: Included
