### PR TITLE
build: update repository agent skills

### DIFF
--- a/.agents/skills/apm-usage/README.md
+++ b/.agents/skills/apm-usage/README.md
@@ -1,0 +1,11 @@
+# apm-usage
+
+## Overview
+
+Safely set up, pin, deploy, audit, and update APM-managed agent dependencies.
+
+## Install
+
+```shell
+apm install aoirint/skills/.apm/skills/apm-usage
+```

--- a/.agents/skills/apm-usage/SKILL.md
+++ b/.agents/skills/apm-usage/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: apm-usage
+description: Select a reviewed APM CLI version, then set up, pin, deploy, audit, and update APM-managed agent dependencies safely. Use when creating or editing apm.yml or apm.lock.yaml, choosing or installing APM, adding an Agent Skill, plugin, or MCP dependency, validating a pinned deployment, or preparing a cooldown-aware update proposal.
+---
+
+# APM Usage
+
+Keep agent context reproducible and reviewable. Select the newest reviewed APM
+release that has completed the seven-day cooldown or has a manifest-recorded
+maintainer exception for a specific unmet gate. Filesystem location and local
+recency do not establish eligibility. Require full commit pins, lockfile
+hashes, and review for every changed third-party dependency.
+
+## 1. Inspect before changing
+
+1. Locate `apm.yml`, `apm.lock.yaml`, `apm-policy.yml`, existing agent
+   directories, and repository guidance. Read `apm_version` and
+   `lockfile_version` from an existing lockfile before running a mutating APM
+   command; treat them as compatibility evidence, not an instruction to keep an
+   older CLI forever.
+2. Read [the bootstrap manifest](references/apm-bootstrap.json). Its version is
+   the newest APM release whose provenance, artifacts, checksums, publication
+   date, and cooldown status this Skill has reviewed. When
+   `cooldown_exception` is present, verify that it identifies the specific
+   unmet gate, reason, approval time, and scope. Do not infer a broader waiver.
+   Do not prefer a newer local `current`, `PATH`, project-local, or legacy
+   executable merely because it is easier to find.
+3. Keep an unpublished consumer project at `version: 0.0.0` in `apm.yml`.
+   Change that version only after its distribution and versioning design is
+   explicitly decided.
+4. Inventory `apm` on `PATH`, project-local copies, and locations reported by
+   the current official installation documentation and the platform's command
+   resolver. Record each resolved executable and `--version`; path precedence
+   does not override cooldown eligibility.
+
+   Select the manifest version when it is already installed and invoke an
+   off-PATH copy by absolute path. Do not modify PATH to satisfy one repository
+   task. If the selected version is absent, use the verified temporary-artifact
+   flow in section 2 instead of installing it implicitly.
+5. If the lockfile records an older APM version than the selected eligible
+   version, capture it for comparison and regenerate it from scratch with the
+   selected executable. Do not edit `apm_version` by hand: remove only the
+   validated project lockfile, run `apm lock`, review the complete result, and
+   then run the frozen install and audit checks. Treat substantial lock-format
+   churn separately from a dependency update.
+6. If the lockfile records a newer, not-yet-eligible APM version, do not execute
+   that CLI merely to preserve its generator version. Report the mismatch and
+   wait for maintainer direction before the destructive regeneration in step 5.
+   After that direction, capture and regenerate the lock by the same procedure
+   as step 5. Selecting the newest normally eligible CLI is not a cooldown
+   exception.
+7. Use the official lockfile migration guidance to understand schema changes,
+   but do not substitute `apm install` for the from-scratch regeneration in
+   step 5. Restore and stop if a frozen or allegedly read-only command rewrites
+   the lockfile unexpectedly.
+8. If `apm.yml` exists, preserve it. Do not run `apm init --yes`, because it
+   overwrites an existing manifest.
+9. If no manifest exists, inspect the repository's agent targets and run
+   interactive `apm init` from the project root. Select only the targets the
+   project actually uses; review the generated `apm.yml` before adding deps.
+10. Treat the CLI and agent dependencies as supply-chain-sensitive code. Check the
+   repository policy and any organization policy before proceeding.
+
+## 2. Obtain the selected eligible APM version safely
+
+Reuse an installed copy only when its exact version matches the selected
+reviewed release. Do not run an unpinned installer or `apm self-update` merely
+to obtain whatever version is newest upstream.
+
+Treat installation, self-update, PATH changes, and replacement of the active
+APM binary as user-environment changes. A request to maintain one repository
+does not authorize them.
+
+Read [the bootstrap manifest](references/apm-bootstrap.json), then consult the
+current [official installation guide](https://microsoft.github.io/apm/getting-started/installation/),
+[`apm self-update` reference](https://microsoft.github.io/apm/reference/cli/self-update/),
+and installer source in the
+[official APM repository](https://github.com/microsoft/apm). Do not reproduce
+their commands, paths, environment variables, or installer behavior in this
+Skill: those are upstream-owned and may change. The manifest remains this
+Skill's source of truth for the reviewed version, release date, artifacts, and
+SHA-256 values.
+
+When the selected version is not installed:
+
+1. Download the exact official release archive named in the bootstrap manifest
+   to a unique operating-system temporary directory. Verify its hard-coded
+   SHA-256 before extraction, extract the complete bundle, and invoke the
+   packaged executable by absolute path. Do not add it to PATH, copy a shim,
+   place it in the repository, or alter the active APM installation.
+2. Confirm `--version` exactly matches the manifest. If the official artifact
+   is not portable on the current platform, cannot preserve its adjacent
+   runtime files, or fails integrity verification, stop instead of inventing an
+   installation layout or choosing an ineligible version.
+3. Remove only the validated task-specific temporary directory after the work
+   finishes. Record the archive source, expected and observed SHA-256,
+   executable path, and version in the handoff.
+4. If the user explicitly requests a persistent installation, then consult the
+   current official sources above and use their documented version-pin and
+   integrity mechanisms. Let the official installer own its layout. Do not
+   alter PATH or replace an active binary without explicit authorization for
+   those specific environment changes.
+5. For an enterprise mirror, use HTTPS, set `APM_NO_DIRECT_FALLBACK=1`, and
+   verify that the mirror serves the identical reviewed artifact and checksum.
+   Do not treat this as a substitute for review of the artifact.
+
+## 2.1 Propose a bootstrap-version refresh
+
+Do not change the bootstrap manifest automatically. Use this proposal flow:
+
+1. Record the current and candidate tags, release URLs, publication dates,
+   platform assets, SHA-256 values, and the candidate cooldown date. Start with
+   the newest candidate that has completed the cooldown, not merely the newest
+   published or locally installed version. A maintainer may instead select one
+   exact newer release and approve a cooldown exception for a concrete defect
+   or operational blocker.
+2. Treat cooldown as a minimum gate, not adoption approval. Review provenance,
+   release notes, installer and artifact integrity, and compatibility from the
+   current official sources. Require explicit maintainer approval.
+3. Run
+   `uv run --no-project --no-config --locked --script <apm-usage-skill>/scripts/propose_bootstrap_update.py`
+   to isolate the locked helper from the consumer repository's uv configuration
+   and collect an eligible candidate without changing files. Attach its JSON
+   output to the proposal.
+4. After approval, obtain the candidate through section 2's temporary
+   artifact flow and run representative lock, frozen-install, audit, and
+   deployed-output checks without changing the active installation or PATH.
+   A reproducible resolver, lock migration, install, audit, or output failure
+   rejects the candidate even after cooldown; keep the current bootstrap and
+   record the evidence instead of trying a newer unreviewed release.
+5. If the candidate passes, run the same isolated command with
+   `--write --confirm-version <candidate>`. It updates only
+   `references/apm-bootstrap.json` and refuses an unconfirmed or mismatched
+   version. Review the manifest diff before committing.
+
+For a maintainer-approved cooldown exception, pass the exact
+`--candidate-version`, `--cooldown-exception-reason`, and deterministic
+`--now` approval timestamp first without `--write`, then repeat with
+`--write --confirm-version <candidate>`. The helper records
+`cooldown_exception` in the manifest and refuses an exception without an exact
+candidate and reason. The exception waives only the time gate for that
+bootstrap CLI release; provenance, checksums, artifact inspection,
+compatibility tests, and dependency review remain required.
+
+Do not use `apm self-update` to perform this refresh.
+
+## Reference sources
+
+| Source | Use |
+| --- | --- |
+| [Official APM repository](https://github.com/microsoft/apm) | Verify supported configuration, CLI behavior, and upstream guidance. |
+| [APM documentation](https://microsoft.github.io/apm/) | Consult the maintained usage and reference documentation. |
+| [Official installation guide](https://microsoft.github.io/apm/getting-started/installation/) | Use the supported version pin and installer-managed locations. |
+| [Official migration guide](https://microsoft.github.io/apm/troubleshooting/migration/) | Handle lockfile schema and CLI upgrades without inventing a migration path. |
+| [`apm self-update` reference](https://microsoft.github.io/apm/reference/cli/self-update/) | Distinguish CLI updates from dependency updates and confirm official rollback behavior. |
+| [APM releases](https://github.com/microsoft/apm/releases) | Review release tags, publication dates, assets, and release notes. |
+| [GitHub Releases API](https://api.github.com/repos/microsoft/apm/releases?per_page=30) | Obtain machine-readable release metadata; this is the endpoint used by the proposal script. |
+| [APM security policy](https://github.com/microsoft/apm/security/policy) | Follow the upstream vulnerability-reporting process. |
+| [Pinned bootstrap manifest](references/apm-bootstrap.json) | Obtain this skill's reviewed version, eligible date, asset names, and SHA-256 values. |
+
+## 3. Add an Agent Skill or dependency
+
+Use this staged workflow for every remote skill, prompt, agent, plugin, hook,
+or MCP dependency:
+
+1. Identify the exact source repository, optional virtual subdirectory,
+   release/tag, and full 40-character commit SHA. Review the source, its
+   release history, declared capabilities, transitive dependencies, and changes
+   that could execute code or add MCP access.
+2. Verify from an authoritative source that the adopted content is at least
+   seven days old. For a virtual subdirectory in a monorepo, identify the last
+   commit that changed that subdirectory at the selected ref and calculate the
+   cooldown from that commit, not from an unrelated later commit elsewhere in
+   the repository. If its age, provenance, or required hash cannot be verified,
+   stop and report the blocker. Do not bypass the cooldown without a documented
+   maintainer exception.
+3. Before committing a third-party skill, determine its license from an
+   authoritative upstream license file or policy. Add or update the
+   repository-root `THIRD_PARTY_NOTICES.md` with its source repository and
+   virtual path, full commit SHA, license identifier and canonical text or URL,
+   plus any supplied copyright or NOTICE text. Do not put this record in an
+   APM-managed target directory such as `.agents/skills/`. Treat a missing or
+   unclear license or required notice as a blocker unless a maintainer records
+   an explicit exception.
+4. Add the dependency to `apm.yml` with the full commit SHA, never a default
+   branch, `latest`, or an unbounded range. When selecting multiple Skills from
+   one repository at one ref, use one object-form dependency with `git`, `ref`,
+   and `skills`; do not encode each Skill as a separate virtual dependency.
+   Keep separate entries only when their repository, ref, or dependency policy
+   differs. Keep MCP entries under the same review gate and do not put tokens
+   in tracked YAML.
+5. Run `apm lock` to resolve and download without deploying to agent targets.
+   Review `apm.lock.yaml`: each dependency must resolve to the expected commit
+   and carry its content hash. In PowerShell checks, wrap variable-cardinality
+   query results in `@(...)` before using `.Count`, indexing, or membership
+   tests; one result otherwise becomes a scalar while multiple results become
+   an array. Assert the expected count and element type. Commit the manifest
+   and lockfile together.
+6. Run `apm install --frozen` only after that review. It must reproduce the
+   reviewed lockfile and must not resolve a new dependency. Never use
+   `--force`, `--allow-insecure`, or an insecure HTTP source unless an explicit
+   documented exception authorizes it.
+7. Run `apm audit --ci` after deployment. Fix lockfile, integrity, drift, or
+   policy findings rather than suppressing them. Add `apm install --frozen` and
+   `apm audit --ci` to the project's existing CI when the user requests CI
+   enforcement.
+
+### 3.1 Add the lightweight project-metadata guard
+
+When a repository already has a source-lint composite action, add the
+repository-owned metadata guard described in [CI guards](references/ci-guards.md).
+It verifies the unpublished project version and the lock generator version
+without downloading or executing APM. Keep it in the existing lint job so
+adoption requires one step rather than a new workflow. Do not make consumer CI
+depend on a path inside the deployed Skill; copy the template into the
+repository's own `.github/actions/check-apm-project/` directory.
+
+The metadata guard is not a replacement for `apm install --frozen` or
+`apm audit --ci`. Add those separately when the requested CI policy includes
+dependency replay, deployed-file integrity, or security auditing.
+
+### 3.2 Maintain a packaged Skill collection
+
+Apply this section only when a repository publishes Skill copies in both an
+authoring target such as `.agents/skills/` and a package directory such as
+`.apm/skills/`.
+
+1. Identify the canonical source and each distributed copy. Use a supported
+   generator when one exists; otherwise update every copy in the same change.
+2. Compare relative file sets and content hashes before release. A missing,
+   extra, or different file is a release blocker, not a cosmetic discrepancy.
+3. After `apm install --frozen`, record the installer-reported target and
+   verify the named Skill at that actual target, rather than assuming a
+   configured or conventional directory was used.
+4. If `apm audit --ci` resolves a different target root, do not call the audit
+   a pass or failure without direct evidence. Record the discrepancy, verify
+   the installed file and lockfile hashes directly, and report the observed
+   behavior for follow-up.
+5. After deployment, review the staged diff as well as the working tree. An
+   installer can rewrite unchanged text with a different line ending; stage
+   only the expected manifest, lockfile, canonical, and deployed outputs, then
+   use `git diff --cached --check` and a content review to distinguish a real
+   generated-file delta from line-ending noise.
+
+### 3.3 Rename or remove packaged local Skills
+
+Apply this section when a local packaged Skill is renamed, consolidated, or
+removed. Treat it as a deployment-ledger change, not a documentation-only
+rename.
+
+1. Before editing, inventory the retiring and destination source folders,
+   deployed paths, resource moves, README index rows, repository references,
+   and every matching entry in `apm.lock.yaml` (`deployments`, deployed-file
+   lists, and local deployed-file hashes).
+2. Move or remove canonical content and update callers first. Preserve
+   deterministic scripts and directly linked references when their behavior
+   remains supported; do not recreate them gratuitously. Regenerate every
+   managed deployment from the canonical source rather than hand-editing
+   `.agents/` output.
+3. Regenerate the lockfile from scratch with the selected reviewed APM CLI
+   whenever the existing ledger still names a retired deployment path, or when
+   a normal lock/install cycle cannot prove that removed paths left the ledger.
+   Do not patch lockfile hashes or deployment entries by hand. Review that no
+   retired path remains before running `apm install --frozen`.
+4. Run `apm install --frozen` and `apm audit --ci`. Treat missing expected
+   files, orphaned retired files, unintegrated outputs, or a source/deployed
+   file-set mismatch as release blockers. If the available generator cannot
+   remove a retired generated path, stop and record the tool limitation rather
+   than claiming the deployment is clean.
+5. Review the complete canonical, deployment, and lockfile diff together.
+   Confirm the installed target contains the destination Skill exactly once and
+   no retired Skill name, resource, or hash record remains.
+
+## 4. Propose updates; do not silently apply them
+
+Pinned dependencies stay unchanged until a maintainer approves an update.
+Create an update proposal, issue, or pull request with no deployment changes
+first:
+
+1. Run `apm outdated` and `apm update --dry-run` to discover candidates
+   without writing files.
+2. For each candidate, record the current and proposed tag and full commit
+   SHA, upstream release URL and date, SHA-256/content-hash changes, source
+   review summary, new transitive dependencies, and any MCP, hook, permission,
+   or target-output changes.
+3. State the earliest eligible adoption date: release date plus seven full
+   days. Keep the proposal open until that date and explicit maintainer
+   approval; a newer upstream release restarts its own cooldown.
+4. After approval, run interactive `apm update` for only the approved package.
+   Review the plan before accepting it, then review the `apm.yml`,
+   `apm.lock.yaml`, and deployed-file diff. Run `apm audit --ci` and commit the
+   result. Re-check the upstream license and notices; update the matching
+   `THIRD_PARTY_NOTICES.md` entry in the same commit when the source, virtual
+   path, commit, license, or attribution changes.
+5. In CI and ordinary repeat installs, keep using `apm install --frozen`.
+   Update discovery and update application must remain separate actions.
+
+## 5. Reconcile third-party notices
+
+Before handoff, reconcile `THIRD_PARTY_NOTICES.md` with the reviewed lockfile:
+
+1. For every third-party skill whose files are committed from an APM target,
+   keep one current notice entry with the source, selected virtual path, locked
+   SHA, license, and required attribution.
+2. When removing a dependency, run `apm prune` and confirm its deployed files
+   are gone before removing its notice entry. Retain the notice when a copy or
+   derivative remains in the repository.
+3. Treat a changed license, copyright, or NOTICE file as an adoption-review
+   change, not a metadata-only update. Resolve it before deploying the new
+   version.
+
+## Completion checklist
+
+- `apm.yml` is present and was not overwritten accidentally.
+- An unpublished project keeps `version: 0.0.0` until its distribution and
+  versioning design is approved.
+- The selected APM CLI was the newest reviewed release that completed the
+  seven-day cooldown or had a manifest-recorded maintainer exception for the
+  specific unmet gate; its absolute path and version were recorded.
+- No PATH, active APM installation, or other user-environment state changed
+  without explicit authorization.
+- Any lock-format migration was explicit and reviewed separately from resolved
+  dependency changes; unexpected lockfile writes were restored and reported.
+- Every remote dependency is pinned to a reviewed full commit SHA.
+- `apm.lock.yaml` is committed and contains the expected resolved commits and
+  content hashes, and its `apm_version` matches the selected eligible CLI.
+- Each adopted release, or the last change to a selected virtual subdirectory,
+  met the seven-day cooldown or has a documented maintainer-approved exception.
+- Each committed APM-deployed third-party skill has one current
+  `THIRD_PARTY_NOTICES.md` entry, including its license and required notices;
+  removed skills have no stale entry unless a copy remains.
+- Packaged collections have matching canonical and distributed file sets and
+  content hashes; the named installed Skill was checked at the
+  installer-reported target.
+- Deployment used `apm install --frozen`; `apm audit --ci` passed in the
+  verified target context, or any target-resolution discrepancy is documented
+  with direct installation and lockfile evidence.
+- Updates have a reviewable, cooldown-aware proposal before application.

--- a/.agents/skills/apm-usage/agents/openai.yaml
+++ b/.agents/skills/apm-usage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "APM Usage"
+  short_description: "Select APM safely and manage pinned agent dependencies"
+  default_prompt: "Use $apm-usage to select an eligible APM version and safely manage this project's pinned agent dependencies."

--- a/.agents/skills/apm-usage/assets/check-apm-project/action.yml
+++ b/.agents/skills/apm-usage/assets/check-apm-project/action.yml
@@ -1,0 +1,94 @@
+name: Check APM project
+description: Check unpublished APM project and lock generator versions.
+
+inputs:
+  expected-apm-version:
+    description: Expected APM CLI version recorded by apm.lock.yaml.
+    required: true
+  expected-project-version:
+    description: Expected unpublished project version in apm.yml.
+    required: false
+    default: "0.0.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Check APM project metadata
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        APM_GUARD_EXPECTED_APM_VERSION: ${{ inputs.expected-apm-version }}
+        APM_GUARD_EXPECTED_PROJECT_VERSION: ${{ inputs.expected-project-version }}
+      run: |
+        python3 - <<'PY'
+        import os
+        import re
+        import sys
+        from pathlib import Path
+
+        top_level_scalar = re.compile(
+            r"^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t]+(.*?))?[ \t]*$"
+        )
+
+
+        def read_top_level_scalar(path: Path, key: str) -> str:
+            matches = []
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if not line or line[0].isspace() or line.startswith("#"):
+                    continue
+                match = top_level_scalar.match(line)
+                if not match or match.group(1) != key:
+                    continue
+                value = (match.group(2) or "").strip()
+                if value.startswith(("\"", "'")):
+                    quote = value[0]
+                    end = value.find(quote, 1)
+                    suffix = value[end + 1 :].strip() if end >= 0 else "invalid"
+                    if end < 0 or (suffix and not suffix.startswith("#")):
+                        value = ""
+                    else:
+                        value = value[1:end]
+                else:
+                    value = re.split(r"[ \t]+#", value, maxsplit=1)[0].rstrip()
+                matches.append(value)
+
+            if len(matches) != 1 or not matches[0]:
+                raise ValueError(
+                    f"{path}: expected exactly one non-empty top-level {key!r}"
+                )
+            return matches[0]
+
+
+        root = Path.cwd().resolve()
+        checks = (
+            (
+                root / "apm.yml",
+                "version",
+                os.environ["APM_GUARD_EXPECTED_PROJECT_VERSION"],
+            ),
+            (
+                root / "apm.lock.yaml",
+                "apm_version",
+                os.environ["APM_GUARD_EXPECTED_APM_VERSION"],
+            ),
+        )
+        errors = []
+        for path, key, expected in checks:
+            try:
+                actual = read_top_level_scalar(path, key)
+            except (OSError, UnicodeError, ValueError) as error:
+                errors.append(str(error))
+                continue
+            if actual != expected:
+                errors.append(f"{path}: {key} is {actual!r}; expected {expected!r}")
+
+        if errors:
+            for error in errors:
+                print(f"error: {error}", file=sys.stderr)
+            raise SystemExit(1)
+
+        print(
+            "APM project metadata is valid "
+            f"(project {checks[0][2]}, APM {checks[1][2]})."
+        )
+        PY

--- a/.agents/skills/apm-usage/references/apm-bootstrap.json
+++ b/.agents/skills/apm-usage/references/apm-bootstrap.json
@@ -1,0 +1,45 @@
+{
+  "version": "v0.26.0",
+  "published_at": "2026-07-18T21:57:33Z",
+  "cooldown_days": 7,
+  "eligible_on": "2026-07-25T21:57:33Z",
+  "release_url": "https://github.com/microsoft/apm/releases/tag/v0.26.0",
+  "download_url_template": "https://github.com/microsoft/apm/releases/download/{version}/{asset}",
+  "assets": [
+    {
+      "platform": "macos-arm64",
+      "archive": "apm-darwin-arm64.tar.gz",
+      "extracted_directory": "apm-darwin-arm64",
+      "sha256": "febddd0a8beb4be7b411e708ed746937a14482d5e0935eb776b7f35e320654df"
+    },
+    {
+      "platform": "macos-x86_64",
+      "archive": "apm-darwin-x86_64.tar.gz",
+      "extracted_directory": "apm-darwin-x86_64",
+      "sha256": "6cc47251bbefabe36224bcc5370c1ef08405d4fd15900b42e11ba672ae29483f"
+    },
+    {
+      "platform": "linux-arm64",
+      "archive": "apm-linux-arm64.tar.gz",
+      "extracted_directory": "apm-linux-arm64",
+      "sha256": "c4d6b5ab6d9bdca3c3c324db7ce8d1c4faf7b317f45a55a50ae2571eaa506d25"
+    },
+    {
+      "platform": "linux-x86_64",
+      "archive": "apm-linux-x86_64.tar.gz",
+      "extracted_directory": "apm-linux-x86_64",
+      "sha256": "3afba455c5283852ba4c392f668be7c27b65bc4a0fa60a8b53a4626c52628431"
+    },
+    {
+      "platform": "windows-x86_64",
+      "archive": "apm-windows-x86_64.zip",
+      "extracted_directory": "apm-windows-x86_64",
+      "sha256": "1b74a90c7ee6373ab2926addd110c1dbc5934a9675e5f436cac4d04f46cce2f5"
+    }
+  ],
+  "cooldown_exception": {
+    "approved_at": "2026-07-24T13:48:14Z",
+    "reason": "APM 0.26.0 fixes audit config-consistency false failures for virtual packages (microsoft/apm#2214).",
+    "scope": "bootstrap-cli-release-time-gate"
+  }
+}

--- a/.agents/skills/apm-usage/references/ci-guards.md
+++ b/.agents/skills/apm-usage/references/ci-guards.md
@@ -1,0 +1,109 @@
+# CI Guards
+
+Use these guards when a repository wants reproducible APM metadata and
+Markdown lint checks without adding an installer to the lint job.
+
+## Contents
+
+- [APM project metadata](#apm-project-metadata)
+- [Markdown lint through pnpm dlx](#markdown-lint-through-pnpm-dlx)
+
+## APM project metadata
+
+The Skill includes `assets/check-apm-project/action.yml` as the reviewed
+template for a small repository-owned Composite Action. Copy the action to
+`.github/actions/check-apm-project/action.yml`. Do not invoke the deployed Skill
+path from CI: that would make a consumer workflow depend on the Skill's
+internal directory structure.
+
+The copied guard checks two repository invariants:
+
+- top-level `version` in `apm.yml` is `0.0.0` for an unpublished project;
+- top-level `apm_version` in `apm.lock.yaml` matches the selected APM version.
+
+Add one step to an existing composite lint action:
+
+```yaml
+- name: Check APM project metadata
+  uses: ./.github/actions/check-apm-project
+  with:
+    expected-apm-version: "0.26.0"
+```
+
+The check uses only the Python standard library available on the selected
+runner and does not download or execute APM. Review the copied Composite Action
+as repository code, and update its caller's expected APM version in the same PR
+that deliberately changes the lock generator version.
+
+If it reports a lock generator mismatch, invoke the reviewed APM executable by
+absolute path, remove only the validated repository's `apm.lock.yaml`, and run
+`apm lock`. Review the full regenerated lock, run `apm install --frozen`, and
+then run `apm audit --ci`. Never repair the version field manually.
+
+## Markdown lint through pnpm dlx
+
+Pin the package version and make pnpm reject packages that have not completed
+seven full days since publication, including packages with missing publication
+times:
+
+```shell
+pnpm \
+  --config.minimumReleaseAge=10080 \
+  --config.minimumReleaseAgeStrict=true \
+  --config.minimumReleaseAgeIgnoreMissingTime=false \
+  --config.minimumReleaseAgeExclude= \
+  dlx markdownlint-cli2@0.22.0 \
+  --config .markdownlint-cli2.yaml \
+  '**/*.md'
+```
+
+[pnpm's `minimumReleaseAge` setting](https://pnpm.io/settings#minimumreleaseage)
+is measured in minutes, so `10080` is seven days. Use pnpm 11 or newer because
+all three fail-closed settings are supported there. Invoke
+the reviewed pnpm executable by its resolved path, confirm `pnpm --version`,
+and keep the strict, missing-time, and empty-exclusion settings explicit rather
+than relying on pnpm defaults or global configuration. Before adopting the
+command, confirm the effective values with the same CLI:
+
+```shell
+pnpm --config.minimumReleaseAge=10080 config get minimumReleaseAge
+pnpm --config.minimumReleaseAgeStrict=true config get minimumReleaseAgeStrict
+pnpm --config.minimumReleaseAgeIgnoreMissingTime=false \
+  config get minimumReleaseAgeIgnoreMissingTime
+pnpm --config.minimumReleaseAgeExclude= config get minimumReleaseAgeExclude
+```
+
+Run the pinned `dlx` command in a clean process with no project-local pnpm
+configuration overriding these command-line values. An exact package version
+does not replace the cooldown gate; keep both.
+
+Confirm that the resolver actually enforces the gate with a safe negative
+control. In a unique operating-system temporary directory, use an isolated
+pnpm store and ask the resolver to add the same reviewed
+`markdownlint-cli2@0.22.0` with an intentionally larger age such as `5256000`
+minutes:
+
+```shell
+probe_dir="$(mktemp -d)"
+(
+  cd "$probe_dir"
+  pnpm \
+    --config.storeDir="$probe_dir/store" \
+    --config.minimumReleaseAge=5256000 \
+    --config.minimumReleaseAgeStrict=true \
+    --config.minimumReleaseAgeIgnoreMissingTime=false \
+    --config.minimumReleaseAgeExclude= \
+    --ignore-scripts \
+    add --lockfile-only markdownlint-cli2@0.22.0
+)
+```
+
+The command must fail with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`; any other
+result is a failed probe. `--lockfile-only --ignore-scripts` prevents package
+or lifecycle-script execution even if the cooldown is ineffective. After this
+negative control, run the real seven-day `dlx` command and require success.
+
+For locally auto-fixable findings, add `--fix` after the package version and
+run the normal lint command again afterward. `markdownlint-cli2 --fix` does not
+repair every rule; line-length findings such as prose reported by MD013 can
+still require a formatter or a meaning-preserving manual edit.

--- a/.agents/skills/apm-usage/scripts/propose_bootstrap_update.py
+++ b/.agents/skills/apm-usage/scripts/propose_bootstrap_update.py
@@ -1,0 +1,142 @@
+# /// script
+# requires-python = ">=3.11,<3.14"
+# dependencies = []
+# [tool.uv]
+# exclude-newer = "P7D"
+# ///
+"""Propose or explicitly pin a reviewed APM release from GitHub."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+MANIFEST_PATH = Path(__file__).parents[1] / "references" / "apm-bootstrap.json"
+API_URL = "https://api.github.com/repos/microsoft/apm/releases?per_page=30"
+
+
+def timestamp(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def semver(tag: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+    if not match:
+        raise ValueError(f"Unsupported release tag: {tag}")
+    return tuple(int(value) for value in match.groups())
+
+
+def request_json(url: str) -> object:
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": "apm-usage-skill"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def request_text(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "apm-usage-skill"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def load_manifest() -> dict:
+    with MANIFEST_PATH.open(encoding="utf-8") as file:
+        manifest = json.load(file)
+    required = {"version", "published_at", "cooldown_days", "eligible_on", "release_url", "download_url_template", "assets"}
+    if required.difference(manifest):
+        raise ValueError("Bootstrap manifest is missing required fields")
+    if manifest["cooldown_days"] < 7:
+        raise ValueError("Bootstrap manifest cooldown must be at least seven days")
+    return manifest
+
+
+def candidate_manifest(
+    current: dict,
+    release: dict,
+    cooldown_exception: dict | None = None,
+) -> dict:
+    assets_by_name = {asset["name"]: asset for asset in release["assets"]}
+    assets = []
+    for asset in current["assets"]:
+        sidecar = assets_by_name.get(f"{asset['archive']}.sha256")
+        if sidecar is None:
+            raise ValueError(f"Release {release['tag_name']} is missing {asset['archive']}.sha256")
+        digest = request_text(sidecar["browser_download_url"]).strip().split()[0]
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(f"Invalid SHA-256 sidecar for {asset['archive']}")
+        assets.append({**asset, "sha256": digest})
+    published_at = timestamp(release["published_at"])
+    candidate = {
+        **{key: value for key, value in current.items() if key != "cooldown_exception"},
+        "version": release["tag_name"],
+        "published_at": published_at.isoformat().replace("+00:00", "Z"),
+        "eligible_on": (published_at + dt.timedelta(days=current["cooldown_days"])).isoformat().replace("+00:00", "Z"),
+        "release_url": release["html_url"],
+        "assets": assets,
+    }
+    if cooldown_exception:
+        candidate["cooldown_exception"] = cooldown_exception
+    return candidate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--now", help="UTC timestamp for deterministic cooldown evaluation")
+    parser.add_argument("--candidate-version", help="Exact newer release selected for a cooldown exception")
+    parser.add_argument(
+        "--cooldown-exception-reason",
+        help="Maintainer-approved reason for waiving only the selected release's time gate",
+    )
+    parser.add_argument("--write", action="store_true", help="Replace the manifest after explicit version confirmation")
+    parser.add_argument("--confirm-version", help="Required with --write; must equal the selected candidate")
+    args = parser.parse_args()
+    if args.write != bool(args.confirm_version):
+        parser.error("--write and --confirm-version must be used together")
+    if bool(args.candidate_version) != bool(args.cooldown_exception_reason):
+        parser.error("--candidate-version and --cooldown-exception-reason must be used together")
+    if args.cooldown_exception_reason and not args.cooldown_exception_reason.strip():
+        parser.error("--cooldown-exception-reason must not be blank")
+    current = load_manifest()
+    now = timestamp(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+    cutoff = now - dt.timedelta(days=current["cooldown_days"])
+    releases = request_json(API_URL)
+    stable_newer = [
+        release for release in releases
+        if not release["draft"] and not release["prerelease"]
+        and semver(release["tag_name"]) > semver(current["version"])
+    ]
+    if args.candidate_version:
+        release = next(
+            (item for item in stable_newer if item["tag_name"] == args.candidate_version),
+            None,
+        )
+        if release is None:
+            raise SystemExit("No matching stable newer candidate for cooldown exception")
+        if timestamp(release["published_at"]) <= cutoff:
+            raise SystemExit("Selected candidate is already cooldown-eligible; omit the exception")
+        exception = {
+            "approved_at": now.isoformat().replace("+00:00", "Z"),
+            "reason": args.cooldown_exception_reason.strip(),
+            "scope": "bootstrap-cli-release-time-gate",
+        }
+    else:
+        eligible = [
+            release for release in stable_newer
+            if timestamp(release["published_at"]) <= cutoff
+        ]
+        release = max(eligible, key=lambda item: timestamp(item["published_at"]), default=None)
+        exception = None
+    candidate = candidate_manifest(current, release, exception) if release else None
+    if args.write:
+        if candidate is None or args.confirm_version != candidate["version"]:
+            raise SystemExit("No matching reviewed candidate to write")
+        with MANIFEST_PATH.open("w", encoding="utf-8", newline="\n") as file:
+            file.write(json.dumps(candidate, indent=2) + "\n")
+    print(json.dumps({"current_version": current["version"], "writes_files": args.write, "candidate": candidate}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/apm-usage/scripts/propose_bootstrap_update.py.lock
+++ b/.agents/skills/apm-usage/scripts/propose_bootstrap_update.py.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.14"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"

--- a/.agents/skills/docker-quality-check/README.md
+++ b/.agents/skills/docker-quality-check/README.md
@@ -1,0 +1,11 @@
+# docker-quality-check
+
+## Overview
+
+Review Dockerfiles, Compose configurations, and container runtime changes.
+
+## Install
+
+```shell
+apm install aoirint/skills/.apm/skills/docker-quality-check
+```

--- a/.agents/skills/docker-quality-check/SKILL.md
+++ b/.agents/skills/docker-quality-check/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: docker-quality-check
+description: >-
+  Quality-check Dockerfiles, Compose configurations, container startup scripts,
+  image CI, and container documentation. Use when creating, editing, or reviewing
+  container build, runtime, orchestration, or publication changes.
+---
+
+# Docker Quality Check
+
+## When to Use
+
+- Use for changes to Dockerfiles, Compose files, container entrypoints, image build
+  automation, or container-facing documentation.
+- Use before committing or publishing container changes.
+
+## Goals
+
+- Keep container builds reproducible, minimal, and suitable for the intended runtime.
+- Validate both Dockerfile syntax and the changed build or Compose behavior.
+- Make third-party images, downloaded tools, and CI actions traceable and reviewable.
+
+## Workflow
+
+1. Read the changed container files and repository guidance. Identify the build targets,
+   runtime user, exposed services, mounted paths, environment variables, and expected
+   startup behavior.
+2. Run the repository's documented container checks. When no project-specific command
+   exists, use `hadolint` for each changed Dockerfile and `docker compose config` for
+   each changed Compose configuration.
+3. Build the affected image or target with `docker build` or `docker compose build`.
+   Pass only the build arguments and secrets required by the documented build contract;
+   never place credentials in image layers, build logs, or committed configuration.
+4. When startup, routing, health checks, or service wiring changes, start the smallest
+   affected service set and exercise its documented health endpoint or smoke check.
+   Stop the test services after verification.
+5. Inspect image and runtime safety: use a non-root user where feasible, keep the final
+   image free of build-only tooling and secrets, define a clear entrypoint, and avoid
+   mutable base-image tags when an immutable digest is practical.
+6. For newly introduced or updated external images, downloaded executables, or GitHub
+   Actions, use `security-check` to assess provenance, version or digest pinning,
+   release age, checksums, permissions, and runtime behavior. Pin GitHub Actions to
+   full commit SHAs with accurate version comments.
+7. Summarize commands run, build and smoke-test results, and every skipped check with a
+   concrete reason.
+
+## CI Tool Pinning
+
+When a workflow installs hadolint, pin both the release version and the SHA-256 of the
+exact platform asset. Download over HTTPS, verify the hash before making the file
+executable, and install it only into the runner's temporary directory. Before changing
+a pin, verify the official release provenance and the repository's required adoption
+cooldown.
+
+```shell
+curl -sSfLO https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-x86_64
+echo "6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47  hadolint-linux-x86_64" | sha256sum -c -
+install -m 0755 hadolint-linux-x86_64 "$RUNNER_TEMP/bin/hadolint"
+```
+
+Replace the version and checksum together only after independently verifying the
+official release asset. Do not use a floating download URL or skip hash verification.
+
+## Default Checks
+
+```shell
+hadolint Dockerfile
+docker build -t local-validation .
+docker compose config
+```
+
+Replace these examples with the repository's documented file paths, build targets, tags,
+and Compose files. Do not treat a successful syntax check as evidence that the image
+builds or starts correctly.

--- a/.agents/skills/docker-quality-check/agents/openai.yaml
+++ b/.agents/skills/docker-quality-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Docker Quality Check"
+  short_description: "Review container build and runtime changes."
+  default_prompt: >-
+    Use $docker-quality-check to review this Dockerfile, Compose, entrypoint, or
+    container CI change for build correctness, runtime safety, pinning, and validation.

--- a/.agents/skills/github-workflow/README.md
+++ b/.agents/skills/github-workflow/README.md
@@ -1,0 +1,11 @@
+# github-workflow
+
+## Overview
+
+Create and review GitHub Actions workflows, repository issues, and pull requests.
+
+## Install
+
+```shell
+apm install aoirint/skills/.apm/skills/github-workflow
+```

--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: github-workflow
+description: >-
+  Quality-check GitHub Actions workflows, repository issues, pull requests, and
+  their comments. Use when creating, editing, reviewing, or documenting CI
+  automation, issue text, PR text, reviews, replies, or squash merges.
+---
+
+# GitHub Workflow
+
+## When to Use
+
+Use this skill to create, update, or review a GitHub artifact. First identify
+the artifact and apply only its relevant workflow:
+
+- GitHub Actions workflow, composite action, or CI policy: use **Actions**.
+- Issue title, body, comment, or thread note: use **Issues**.
+- Pull request title, body, review, reply, thread note, or squash merge: use
+  **Pull requests**.
+
+Use `security-check` for security- or supply-chain-sensitive content and
+`prose-quality-check` for nuanced explanatory prose.
+
+## Goals
+
+- Keep automation deterministic, least-privilege, and reviewable.
+- Keep issue and pull request artifacts concise, accurate, and explicitly
+  AI-assisted when significant AI assistance was used.
+- Preserve repository templates and policies without inventing unavailable
+  requirements.
+
+## Workflow
+
+### Actions
+
+1. Inspect changed workflow or action files and the repository guidance that
+   describes them.
+2. Check triggers, branch filters, merge-queue behavior, and
+   `workflow_dispatch` against the intended responsibility. Preserve
+   established publication triggers and canonical version sources unless the
+   request explicitly replaces them. Design boundaries around events,
+   privilege, and lifecycle:
+   - A pull-request entry workflow validates untrusted proposed source and
+     includes `merge_group` when a merge queue uses required checks.
+   - An integration-branch entry workflow re-runs required validation on the
+     exact pushed commit. Use a read-only `plan` job only for canonical version
+     or publication state, and make build and publication use direct `needs`
+     dependencies.
+   - For reusable source validation, use event-owned entry workflows: a
+     default-branch push workflow revalidates merged source, while a separate
+     pull-request workflow validates proposed source and merge-queue entries.
+     Reuse one local Composite Action for the same-runner validation sequence.
+     Do not combine those push and pull-request events into one validation
+     workflow: their cancellation policy and source-trust boundary differ.
+     Retire an older entry workflow only after confirming it duplicates that
+     responsibility; do not remove a workflow that owns a distinct release or
+     integration event.
+   - Name jobs for visible responsibility: `lint`, optional `test`, optional
+     `plan`, `build`, and `release`. Use a precisely named Composite Action
+     only for a reusable same-runner sequence.
+   - Do not emulate a direct dependency with API polling, an `await-quality`
+     job, or an unrelated workflow. Add `workflow_dispatch` only for a
+     documented diagnostic or recovery operation. Use `workflow_run` only for
+     a separately reviewed trust boundary.
+3. Check workflow and job `permissions`. Start from `contents: read`, grant
+   only required access, and document unusual write access. Check concurrency
+   groups and cancellation rules for PRs, pushes, releases, merge queues, and
+   publishing. Keep default-branch validation uncancelled; cancel superseded
+   pull-request and merge-queue runs with a group keyed by pull-request number
+   or ref. In read-only checkout jobs, set `persist-credentials: false` unless
+   a later step demonstrably needs repository credentials.
+4. Check runner labels, local composite actions, expressions, comments, cache
+   paths, and suppressions. Read
+   [runner-selection.md](references/runner-selection.md) when selecting or
+   changing a GitHub-hosted runner. Validate action inputs against documentation
+   or metadata for the exact pinned version. Use a Composite Action for a
+   stable same-runner sequence; use a reusable workflow only when job-level
+   matrix, outputs, or permission boundaries require it. Before restricting an
+   Actions allowlist, inventory `uses:` references in entry workflows and every
+   reachable local composite action or reusable workflow. Retain only the
+   required external action or reusable-workflow names; when full-SHA pinning
+   is enforced, allow an individual name with `@*` so new pinned versions do
+   not require repository-setting changes. Do not wildcard an owner or all
+   actions without an approved policy.
+   Give every `uses:` step a responsibility-revealing `name`. Keep version comments on
+   the same line as full-SHA external pins in pinact format, and add concise comments
+   before security- or lifecycle-sensitive steps explaining the design intent rather
+   than restating the step name.
+5. Pin third-party actions and reusable workflows to complete commit SHAs with
+   accurate version comments. For external actions, downloaded tools, or
+   containers, use `security-check` to review provenance, release age, pinning,
+   permissions, and runtime behavior.
+6. Run documented `actionlint`, ShellCheck, and `pinact` checks. Use
+   `pinact run --check --min-age 7` and `GITHUB_TOKEN` when available. Check
+   standalone changed automation shell scripts with ShellCheck; record an empty
+   target scope when none exist. Record each changed external action's full SHA,
+   release tag, publisher/provenance, release-age result, and validation results in
+   the pull request or equivalent change record.
+7. For publishing workflows, gate immutable publication on all required quality
+   and build results for the exact source commit. Retain verified build
+   artifacts, derive release identity from the canonical version source, make
+   retries idempotent, verify existing immutable releases and expected assets,
+   isolate credentials, and use `security-check` for final artifacts.
+8. For repository enforcement, compare required status-check contexts with
+   current workflow job names and verify integration freshness, merge-queue
+   compatibility, release immutability, tag rules, Actions permissions, and
+   protected environments. Unless an approved repository policy intentionally
+   differs, require these repository settings:
+   - Enable release immutability.
+   - Allow squash merging only; use `Pull request title` as the default squash
+     commit-message format.
+   - Always suggest updating pull request branches, allow auto-merge, and
+     automatically delete head branches.
+   - Allow actions and reusable workflows from the repository owner and
+     selected non-owner publishers only; require every action and reusable
+     workflow to be pinned to a full-length commit SHA.
+   - Default `GITHUB_TOKEN` permissions to read repository contents and
+     packages, and do not allow GitHub Actions to create or approve pull
+     requests.
+   - Require approval before fork pull-request workflows run for every
+     external contributor.
+   - Maintain a default-branch ruleset named `default` that targets the
+     default branch, allows repository-admin bypass only through pull
+     requests, restricts deletions,
+     requires pull requests before merging with squash as the only allowed
+     merge method, requires status checks to pass, and blocks force pushes.
+     Treat this required pull-request-only administrator bypass as a baseline
+     setting, not as a policy exception; evaluate any additional bypass actors
+     or exceptions separately.
+   Build an evidence map for every baseline setting from that repository's
+   current API response and post-change read-back. Never infer compliance from
+   a related setting, a prior repository audit, or an API default. Treat an
+   unsupported endpoint as unverified rather than applied. For an apply
+   request, set each requested baseline value explicitly even when its
+   pre-change value was not captured; for an audit-only request, leave that
+   value unverified.
+   Before creating or changing required status checks, verify that every
+   selected context is a current job name that runs on pull requests (and on
+   `merge_group` when a merge queue is used). Do not create a ruleset that can
+   block every merge because its required checks cannot run.
+   When the default ruleset is missing or incomplete, apply every safe baseline
+   rule first. If no current job context can safely be required, omit only the
+   required-status-checks rule, record the ruleset as incomplete, then add or
+   adapt pull-request validation and update the ruleset after observing a
+   successful run. Read [repository-enforcement.md](references/repository-enforcement.md)
+   for the ordered recovery flow and `gh` API command templates.
+   Mark inaccessible settings as unverified and record any approved policy
+   exception explicitly.
+9. Summarize actionlint, ShellCheck, pinact, other automated checks,
+   AI-assisted inspections, and skipped checks separately.
+
+### Issues
+
+1. Identify whether the artifact is an issue title, body, reply, or combined
+   update. For significant AI assistance, put the applicable alert at the very
+   top:
+
+   ```markdown
+   > [!WARNING]
+   > This issue was created with assistance from LLMs.
+   ```
+
+   Use `This comment was created with assistance from LLMs.` for replies.
+2. Make titles concise and specific. Keep bodies and replies concise, using
+   only useful sections such as `Summary`, `Details`, `Acceptance Criteria`,
+   `Verification`, `Notes`, `Findings`, or `Next Steps`. For bugs, state
+   expected and actual behavior and useful reproduction steps.
+3. Write in English except for exact source material. Use bullets, backticks,
+   explicit uncertainty, and summaries rather than large logs or diffs. Never
+   describe AI-performed work as manual.
+4. Add `Update Note` or `Discussion Note` only when requested. Put
+   `Request addressed: ...` after the required alert and before the note
+   heading; label inferences and omit secrets and private paths.
+5. With `gh`, write Markdown to a temporary file and pass `--body-file`.
+   Verify stored issue bodies with `gh issue view --json body` and stored
+   replies when possible, then remove temporary files.
+
+### Pull requests
+
+1. Identify the artifact: title, body, review, reply, thread note, or squash
+   merge. For titles, enforce
+   `<type>[optional scope][optional !]: <description>` and use
+   `commit-message-quality-check` for type and breaking-change notation.
+2. Before drafting or replacing a body, read the current PR template and
+   contributor guidance. Follow only visible headings, required checkboxes, and
+   applicable sections. If no template exists, use
+   [fallback-pr-body.md](references/fallback-pr-body.md). Never infer a CLA,
+   contributor agreement, checklist, sign-off, or policy from the fallback.
+3. For significant AI assistance, put this alert at the absolute top of PR
+   bodies:
+
+   ```markdown
+   > [!WARNING]
+   > This pull request was created with assistance from LLMs.
+   ```
+
+   Use `This comment was created with assistance from LLMs.` for reviews,
+   replies, and thread notes. Preserve any existing alert after a blank line;
+   the LLM alert must be exactly once and first.
+4. Keep automated commands, CI results, non-AI manual checks,
+   screenshots/videos, and AI-assisted inspections distinct. Under
+   `## Testing`, put AI-assisted work in `### AI-assisted inspections` after
+   automated checks with `Request: ...` and nested `AI-assisted result: ...`.
+   State skipped verification and never describe AI work as manual.
+5. Use `Update Note`, `Discussion Note`, or `Review Note` only when requested.
+   Put `Request addressed: ...` after the required alert; group retrospective
+   notes by meaningful theme, label inferences, and omit secrets, private
+   paths, and hidden reasoning.
+6. Before writing an AI-assisted body or comment, run
+   `scripts/check_llm_disclosure.py` against the candidate. For a
+   disclosure-only repair, pass the exact prior body. After writing, fetch the
+   complete JSON response and run the helper against that response and the
+   candidate. For multi-artifact work, preflight every candidate, verify each
+   write immediately, audit all targets at the end, and report success only
+   when every target has exactly one required top alert and a matching body.
+7. With `gh`, use `--body-file`. Verify the complete JSON `body` as one string
+   against the candidate, allowing only terminal-newline normalization; in
+   PowerShell do not assign line-oriented `--jq` output to verify multiline
+   bodies. Remove temporary files.
+8. Before `gh pr merge` creates a squash or merge commit, resolve and pass the
+   exact head SHA with `--match-head-commit`. Build and validate the exact
+   multiline candidate commit message in a file with
+   `git interpret-trailers --parse`, require each expected trailer exactly
+   once, test the stored-message JSON parser with a fixture, merge with the
+   same body file, then verify `commit.message` from
+   `repos/{owner}/{repo}/commits/{sha}` using raw JSON. Treat post-merge
+   verification as secondary to pre-mutation validation.
+
+## Resources
+
+- [runner-selection.md](references/runner-selection.md): GitHub-hosted runner
+  selection and image-lifecycle guidance.
+- [fallback-pr-body.md](references/fallback-pr-body.md): fallback PR template
+  when no repository template applies.
+- [repository-enforcement.md](references/repository-enforcement.md): recovery
+  flow and `gh` command templates for Actions policies and default rulesets.
+- `scripts/check_llm_disclosure.py`: validate required LLM disclosure,
+  disclosure-only repairs, and stored-body preservation.

--- a/.agents/skills/github-workflow/agents/openai.yaml
+++ b/.agents/skills/github-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Workflow"
+  short_description: "Create and review GitHub artifacts."
+  default_prompt: "Use $github-workflow to create, review, or update a GitHub Actions workflow, issue, or pull request."

--- a/.agents/skills/github-workflow/references/fallback-pr-body.md
+++ b/.agents/skills/github-workflow/references/fallback-pr-body.md
@@ -1,0 +1,164 @@
+# Fallback Pull Request Body
+
+Use this fallback only when the repository has no applicable pull request
+template. If a repository template exists, the live template takes precedence.
+Apply repository-specific requirements only when they are present in current
+repository guidance. Do not infer a CLA, checklist, sign-off, or other policy
+from this generic scaffold.
+
+## Contents
+
+- [Fallback Scaffold](#fallback-scaffold)
+
+## Fallback Scaffold
+
+Keep the universal headings below. When a section has no applicable content,
+write `None` or `Not applicable` instead of removing the heading. Add a
+repository-specific section only when current repository guidance requires it.
+
+````markdown
+<!--
+If significant AI assistance affected this pull request, put this alert at the
+very top of the PR body:
+
+> [!WARNING]
+> This pull request was created with assistance from LLMs.
+
+Then describe the AI assistance under "AI disclosure" below.
+-->
+
+## Summary
+
+<!--
+Briefly describe what changed, who it affects, and why it is useful.
+If this pull request mixes unrelated behavior, documentation, refactors, or
+cleanup, split it or explain why the work should stay together.
+If the title or commits include `!` or `BREAKING CHANGE`, include a
+`### Breaking Changes` subsection.
+Treat a change as breaking when it removes, renames, or incompatibly changes
+public behavior, documented workflows, configuration, package or release
+behavior, compatibility guarantees, or other project-facing contracts that
+users, maintainers, automation, or downstream packaging reasonably rely on.
+
+Optional H3 examples:
+### User impact
+### Contributor impact
+### Maintainer impact
+### Breaking Changes
+-->
+
+## Related Issues
+
+<!--
+Prefer Markdown list items for GitHub issues or pull requests so GitHub can
+render rich references.
+Use closing keywords, such as "Closes #123", when this pull request should
+close an issue.
+For non-GitHub references, include enough context for reviewers to understand
+why the link matters.
+Use "None" if there is no related issue.
+
+Markdown list examples:
+- Closes #123
+- Refs #456
+- Refs owner/repository#789
+-->
+
+## Notes for reviewers
+
+<!--
+Share non-testing context that helps reviewers understand or prioritize this
+pull request.
+For example, mention review focus, trade-offs, compatibility risks,
+generated outputs, packaging concerns,
+or areas that need extra attention for reasons other than AI assistance.
+-->
+
+### Proposed merge attribution
+
+<!--
+Keep every potential squash-merge co-author reviewable from PR creation through
+updates. Include the author of an implemented issue and every material design
+or snippet provider by default; a reviewer must explicitly mark a candidate
+"Not applicable" to exclude them.
+
+For a human candidate, record the public GitHub account and immutable numeric
+user ID, a non-private contribution basis, status, and the resolved trailer:
+- @login (GitHub user ID: 123)
+  - Resolved trailer: Co-authored-by: login <GitHub-provided-noreply@example.com>
+  - Basis: Implemented issue #123 / material design or snippet contribution.
+  - Status: Included / Needs identity / Needs review / Not applicable
+
+Do not add the PR creator or the person who merges merely because of those
+roles. GitHub squash merge records the PR creator as primary Git author, but
+that can differ from the material contributors. If the creator is not material
+to the final diff, mark this `Needs review` and do not merge until a maintainer
+confirms that attribution or selects another authorized integration path. A
+review comment or approval alone is not a candidate. Include every final-diff
+PR-head commit author and existing co-author trailer unless already the PR
+creator's primary Git author. If GitHub applied a review suggestion that remains
+in the final diff, include its suggestion provider and applier unless already
+the PR creator's primary Git author, and record the source commit SHA or review
+URL here.
+
+Use a contributor-supplied GitHub-provided noreply address for every human
+trailer by default; never synthesize one from @login or numeric ID. Use a Public
+Email only when the contributor explicitly directs that choice and GitHub
+currently exposes the exact address; record the choice here. An existing
+trailer is reusable only when its GitHub author association proves the same
+account. If any candidate's contribution, applicability, account, exact email,
+trailer, or status is uncertain, use Needs identity or Needs review and do not
+merge.
+Do not use a legacy LOGIN@users.noreply.github.com fallback. State "None
+proposed" if no candidates apply. Make all candidate/status/identity changes
+reviewable; do not silently remove or replace an entry.
+-->
+
+### AI disclosure
+
+<!--
+If AI assistance significantly affected this pull request, disclose it here.
+Mention what the AI helped with, how you reviewed or adapted the result, and
+any AI-assisted areas you did not review closely.
+Use "None" if no significant AI assistance was used.
+
+Optional H3 examples:
+### Review focus
+### Lower-confidence areas
+-->
+
+## Testing
+
+<!--
+List the checks you ran and their results.
+Include commands, manual in-game checks, screenshots, or videos when relevant.
+For docs-only changes, mention proofreading, link checks, formatting checks,
+or "Not run - docs only."
+If you did not run a relevant check, explain why.
+You are responsible for masking personal information, local absolute paths,
+access tokens, and other sensitive details before posting logs, screenshots,
+or videos.
+Do not present AI-performed review, inspection, editing, verification, or other
+work as "manual". For example, if you include AI-assisted inspection, list a
+short `Request: ...` summary first, nest the `AI-assisted result: ...` under it,
+and clearly label the result as AI-assisted.
+
+Optional testing structure:
+### Build log
+
+<details>
+
+```plain
+$ DOTNET_CLI_UI_LANGUAGE=en dotnet build
+Paste the relevant output here.
+```
+
+</details>
+
+### Automated checks
+### AI-assisted inspections
+### Manual checks
+### Screenshots / videos
+-->
+
+````

--- a/.agents/skills/github-workflow/references/repository-enforcement.md
+++ b/.agents/skills/github-workflow/references/repository-enforcement.md
@@ -1,0 +1,158 @@
+# Repository Enforcement Recovery
+
+Use this flow when a default-branch ruleset is missing or lacks required
+pull-request or status-check rules. Run the commands from the target
+repository with authenticated `gh`; replace `OWNER/REPO`, check contexts, and
+full commit SHAs with observed values.
+
+## Contents
+
+- [Inventory before changing policy](#1-inventory-before-changing-policy)
+- [Apply the safe fallback ruleset](#2-apply-the-safe-fallback-ruleset)
+- [Make a required-check context safe to require](#3-make-a-required-check-context-safe-to-require)
+- [Restrict Actions without breaking composites](#4-restrict-actions-without-breaking-composites)
+- [Create or complete the default ruleset](#5-create-or-complete-the-default-ruleset)
+- [Verify the stored policy](#6-verify-the-stored-policy)
+
+## 1. Inventory before changing policy
+
+```powershell
+$repo = 'OWNER/REPO'
+gh api "repos/$repo" --jq '{default_branch,allow_squash_merge,allow_merge_commit,allow_rebase_merge,allow_auto_merge,allow_update_branch,delete_branch_on_merge,squash_merge_commit_title,squash_merge_commit_message}'
+gh api "repos/$repo/immutable-releases"
+gh api "repos/$repo/actions/permissions"
+gh api "repos/$repo/actions/permissions/selected-actions"
+gh api "repos/$repo/actions/permissions/workflow"
+gh api "repos/$repo/rulesets"
+```
+
+Build a per-setting evidence map from these responses and from the read-back
+after every mutation. Record the endpoint, observed value, and result as
+`verified`, `unverified`, or an approved exception. Treat an unavailable
+setting as unverified; do not infer a fork-workflow approval policy, merge
+method, or ruleset bypass from another repository or a related setting.
+For an apply request, set every requested baseline value explicitly even if
+the pre-change response omitted it; for an audit-only request, retain that
+omission as unverified.
+
+The fork-contributor approval endpoint can return `404` for personal-owner
+repositories. Do not report that policy as applied in that case; record it as
+unverified and use the repository settings UI or a supported API when one is
+available.
+
+## 2. Apply the safe fallback ruleset
+
+When no check context has been observed on a pull request, create or update
+the `default` ruleset with every other baseline rule: target the default
+branch, restrict deletions and force pushes, require pull requests, allow only
+squash merging, and allow repository-admin bypass only on pull requests.
+Omit only `required_status_checks`; record the ruleset as incomplete and do
+not claim status-check enforcement.
+
+Use the template in section 5 after removing its
+`required_status_checks` object. For an existing ruleset, preserve unrelated
+rules and send the complete reviewed replacement with `PUT`.
+
+## 3. Make a required-check context safe to require
+
+1. Add or adapt a validation workflow that runs the intended job on
+   `pull_request`. Add `merge_group` when the repository uses a merge queue.
+2. Give the job a stable visible name, such as `lint` or `test`.
+3. Merge that workflow change to the default branch.
+4. Open a pull request and wait for a successful run. Confirm the exact
+   context before adding it to the ruleset:
+
+   ```powershell
+   gh pr checks <number> --required
+   ```
+
+Do not require a job that runs only on `push`, a release job, or a context
+whose current name was not observed on a pull request.
+
+## 4. Restrict Actions without breaking composites
+
+Inventory `uses:` in workflow files and all reachable local composite actions
+or reusable workflows. Preserve local actions and GitHub-owned actions; allow
+only the external action or reusable-workflow names that the inventory finds.
+Keep full-SHA pinning required for workflow execution, but allow each selected
+name with `@*` so updating a pinned version does not require a settings change.
+Do not wildcard an owner or all actions.
+
+Set `allowed_actions=selected`, `sha_pinning_required=true`,
+`github_owned_allowed=true`, and `verified_allowed=false` explicitly during an
+apply. Do not assume an omitted pre-change SHA-pinning value was already safe.
+
+When the inventory finds no external `uses:` reference, set selected actions
+with GitHub-owned actions allowed, Marketplace verified creators disallowed,
+and no `patterns_allowed[]` entries. This is a valid least-privilege result;
+downloaded tools are not Action allowlist entries and still require the
+separate `security-check` review.
+
+```powershell
+gh api --method PUT "repos/$repo/actions/permissions" `
+  -F enabled=true -f allowed_actions=selected -F sha_pinning_required=true
+
+gh api --method PUT "repos/$repo/actions/permissions/selected-actions" `
+  -F github_owned_allowed=true -F verified_allowed=false `
+  -f 'patterns_allowed[]=EXTERNAL_OWNER/ACTION@*'
+
+gh api --method PUT "repos/$repo/actions/permissions/workflow" `
+  -f default_workflow_permissions=read `
+  -F can_approve_pull_request_reviews=false
+```
+
+Repeat `patterns_allowed[]` only for additional observed external action or
+reusable-workflow names. Read back all three endpoints after the change.
+
+## 5. Create or complete the default ruleset
+
+Save the following JSON as `ruleset.json` after replacing `lint` with an
+observed pull-request check context. Repository role ID `5` is the `admin`
+role; its bypass mode is limited to pull requests. If no context is available,
+remove the complete `required_status_checks` object and apply the fallback from
+section 2.
+
+```json
+{
+  "name": "default",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "pull_request" }
+  ],
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "allowed_merge_methods": ["squash"] } },
+    { "type": "required_status_checks", "parameters": {
+      "strict_required_status_checks_policy": true,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [{ "context": "lint" }]
+    } }
+  ]
+}
+```
+
+```powershell
+gh api --method POST "repos/$repo/rulesets" --input ruleset.json
+```
+
+For an existing ruleset, fetch its detail before changing it. Preserve every
+unrelated rule; identify extra bypass actors and other exceptions separately
+instead of silently treating them as the administrator baseline. Send only the
+complete, reviewed replacement to `PUT repos/$repo/rulesets/<id>`.
+
+## 6. Verify the stored policy
+
+```powershell
+gh api "repos/$repo/rulesets" --jq '.[] | select(.name == "default") | .id'
+gh api "repos/$repo/rulesets/<id>"
+```
+
+Confirm the target is `~DEFAULT_BRANCH`, deletion and force pushes are
+restricted, pull requests allow only squash merging, the observed check is
+required, and the only baseline bypass is repository-admin with
+`pull_request` mode. Also read back the repository merge settings, immutable
+releases, both Actions policy endpoints, and workflow token permissions; mark
+every unavailable value unverified.

--- a/.agents/skills/github-workflow/references/runner-selection.md
+++ b/.agents/skills/github-workflow/references/runner-selection.md
@@ -1,0 +1,132 @@
+# GitHub-hosted Linux Runner Selection
+
+Select a runner per job from its actual resource, isolation, tool, and duration requirements. Do
+not copy one workflow-wide label into every job without checking those requirements.
+
+## Contents
+
+- [Start from the oldest supported GA image](#start-from-the-oldest-supported-ga-image)
+- [Prefer `ubuntu-slim` for lightweight jobs](#prefer-ubuntu-slim-for-lightweight-jobs)
+- [Choose a full Ubuntu VM deliberately](#choose-a-full-ubuntu-vm-deliberately)
+- [Operate image retirement as a recurring lifecycle](#operate-image-retirement-as-a-recurring-lifecycle)
+- [Validate the selection](#validate-the-selection)
+
+## Start from the oldest supported GA image
+
+For a job whose output or validation establishes an OS compatibility floor, choose the oldest
+versioned GitHub-hosted GA image that the `actions/runner-images` repository currently lists for the
+required OS and architecture. For Ubuntu, this maximizes compatibility with older glibc consumers;
+newer glibc is not generally backward-runnable on an older distribution. Apply the same
+oldest-supported baseline to Windows and macOS support, while treating architecture, Xcode/Visual
+Studio availability, and artifact type as separate constraints.
+
+Discover the label at review time; do not copy a once-current version from this Skill. Use an
+explicit version label such as `ubuntu-<version>`, `windows-<version>`, or `macos-<version>` so a
+moving `*-latest` alias cannot silently raise the compatibility floor. Beta images do not count as
+the oldest supported GA baseline and do not replace it before GA.
+
+An earlier support cutoff is allowed when current evidence shows that the old image prevents a
+required library/toolchain, materially harms performance or reliability, creates disproportionate
+maintenance cost, or cannot meet security/support obligations. Record the evidence, affected users
+and artifacts, replacement image, migration checks, and announced support boundary. Convenience
+alone is not evidence.
+
+## Prefer `ubuntu-slim` for lightweight jobs
+
+Use `ubuntu-slim` when all of these conditions hold:
+
+- The job is short-running with enough measured headroom below the fixed 15-minute limit.
+- One x64 CPU, 5 GB RAM, and 14 GB storage are sufficient.
+- The job works in an unprivileged container on a shared VM.
+- Every required command is in the current slim image inventory or is installed explicitly from a
+  reviewed, pinned, integrity-checked source.
+- Every external or local action used by the job is compatible with the slim environment.
+- The job does not build, package, link, or validate a native artifact whose glibc/OS compatibility
+  floor is part of the supported product contract.
+
+Good candidates include repository metadata checks, issue or release API automation, small
+format/lint/type/test jobs, and lightweight artifact assembly or publication. Measure the real job;
+the category alone does not prove it fits.
+
+`ubuntu-slim` is not a smaller full VM. GitHub provisions an unprivileged container with a minimal
+tool set. Do not select it for jobs that require filesystem mounts, Docker-in-Docker, low-level
+kernel features, nested virtualization, emulators, or other privileged host access. Treat Docker
+container actions and service containers as unsupported until current official documentation and a
+representative run prove the exact use case works. The installed Docker client does not imply that
+a usable Docker daemon is available.
+
+Avoid `ubuntu-slim` for typical heavyweight CI/CD builds, large native compilation, desktop/mobile
+packaging toolchains, or jobs whose duration can approach 15 minutes. Split a genuinely lightweight
+preflight or publication phase from a heavyweight build when the dependency graph remains explicit;
+do not split jobs merely to claim slim usage.
+
+## Choose a full Ubuntu VM deliberately
+
+Use a standard Ubuntu VM when the job needs more CPU or memory, a full preinstalled toolchain,
+privileged VM behavior, longer execution, or an OS/native ABI compatibility contract. Select the
+oldest currently supported GA Ubuntu label unless a documented constraint justifies an earlier
+support cutoff. Use `ubuntu-latest` only when automatically following GitHub's newest stable Ubuntu
+image is an intended maintenance policy and migration risk has been accepted.
+
+Do not infer that `-latest` means the newest upstream Ubuntu release; it means GitHub's latest stable
+hosted image and changes over time.
+
+## Operate image retirement as a recurring lifecycle
+
+GitHub supports at most two GA images plus one beta per OS family and begins deprecating the oldest
+label after a newer OS image reaches GA. Treat the runner selection as maintained support data, not
+a one-time YAML choice.
+
+1. On every runner-label change, and at least monthly while a repository uses a versioned hosted
+   image, review the current `actions/runner-images` **Available Images**, releases, and open pinned
+   **Announcement** issues. Record the review date and the oldest eligible GA label for each
+   supported OS/architecture family.
+2. When a new GA image appears or a dated deprecation announcement names the selected image, open or
+   update a tracked migration item within one normal maintenance cycle. Capture the announcement
+   URL, announcement date, scheduled brownouts or phased withdrawal, final removal date, affected
+   workflows/artifacts, and the next-oldest supported replacement.
+3. Validate the replacement in parallel before changing the declared support floor: dependency and
+   tool availability, compiler/runtime versions, native artifact compatibility, packaging,
+   performance, cache behavior, and representative workflow duration.
+4. Set the repository's cutoff and merge the versioned-label migration before the first scheduled
+   brownout or other service-disruption phase. Leave at least one normal release/maintenance cycle
+   for rollback when the announcement lead time permits. If GitHub publishes only a final removal
+   date, choose an earlier internal cutoff with the same rollback window; do not wait for removal.
+5. Remove the retired label and obsolete conditionals together, publish the support-boundary change
+   where users and maintainers expect it, and verify the first scheduled runs on the replacement.
+6. Continue the monthly review on the replacement image. A completed migration starts the same
+   lifecycle again; it does not close runner maintenance permanently.
+
+The announcement begins GitHub's administrative deprecation process; brownouts and phased routing
+are the operational disruption phase that repositories must precede. If an announcement provides
+too little lead time for the normal cycle, migrate immediately and record the reduced validation or
+rollback window rather than running into a brownout.
+
+Apply this lifecycle to Windows and macOS too. It is acceptable to drop an older image before GitHub
+does when library/toolchain compatibility, performance, reliability, security, or maintenance
+evidence justifies it, but follow the same tracked decision, parallel validation, communicated
+cutoff, and post-migration verification.
+
+## Validate the selection
+
+1. Read the current GitHub-hosted runner reference and `ubuntu-slim` software inventory before a
+   migration. Also read `actions/runner-images` Available Images, releases, and dated Announcement
+   issues; runner capabilities, installed versions, and retirement dates can change.
+2. Inventory shell commands, local actions, external actions, package installation, caches,
+   containers, services, artifacts, permissions, and expected peak resource use for each job.
+3. Set `timeout-minutes` to at most 15 on a slim job. Leave operational headroom rather than using
+   the limit as the expected duration.
+4. Run every changed slim job on a representative event. Check setup logs, action compatibility,
+   elapsed time, peak behavior, and outputs; a YAML-only review is insufficient.
+5. Keep heavy and platform-specific jobs on the full runner they require. Record why each exception
+   cannot use slim so future reviews can reconsider it.
+6. For every compatibility-bearing job, record why the selected version is the oldest supported GA
+   image or the evidence that justified an earlier support cutoff.
+
+Primary references:
+
+- <https://docs.github.com/en/actions/reference/runners/github-hosted-runners>
+- <https://github.com/actions/runner-images#available-images>
+- <https://github.com/actions/runner-images#software-and-image-support>
+- <https://github.com/actions/runner-images/issues?q=is%3Aissue+label%3AAnnouncement>
+- <https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md>

--- a/.agents/skills/github-workflow/scripts/check_llm_disclosure.py
+++ b/.agents/skills/github-workflow/scripts/check_llm_disclosure.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Validate required LLM disclosure and pull-request body preservation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+DISCLOSURES = {
+    "pull-request": (
+        "> [!WARNING]\n"
+        "> This pull request was created with assistance from LLMs."
+    ),
+    "comment": (
+        "> [!WARNING]\n"
+        "> This comment was created with assistance from LLMs."
+    ),
+}
+
+
+def read_text(path: Path) -> str:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        return stream.read()
+
+
+def read_body(args: argparse.Namespace) -> str:
+    if args.body_file is not None:
+        return read_text(args.body_file)
+
+    with args.body_json_file.open("r", encoding="utf-8", newline="") as stream:
+        document = json.load(stream)
+    if not isinstance(document, dict) or not isinstance(document.get("body"), str):
+        raise ValueError("JSON must contain one string-valued 'body' property")
+    return document["body"]
+
+
+def disclosure_prefixes(disclosure: str) -> tuple[str, str]:
+    lf_prefix = disclosure + "\n\n"
+    crlf_prefix = disclosure.replace("\n", "\r\n") + "\r\n\r\n"
+    return lf_prefix, crlf_prefix
+
+
+def matches_candidate(body: str, candidate: str) -> bool:
+    """Compare bodies, permitting only one terminal newline representation."""
+    if body == candidate:
+        return True
+
+    def without_terminal_newline(value: str) -> str:
+        if value.endswith("\r\n"):
+            return value[:-2]
+        if value.endswith(("\n", "\r")):
+            return value[:-1]
+        return value
+
+    return without_terminal_newline(body) == without_terminal_newline(candidate)
+
+
+def validate(args: argparse.Namespace) -> list[str]:
+    body = read_body(args)
+    disclosure = DISCLOSURES[args.kind]
+    normalized = body.replace("\r\n", "\n").replace("\r", "\n")
+    required_prefix = disclosure + "\n\n"
+    errors: list[str] = []
+
+    if not normalized.startswith(required_prefix):
+        errors.append("required LLM disclosure is not the absolute first block")
+    if normalized.count(disclosure) != 1:
+        errors.append("required LLM disclosure must appear exactly once")
+
+    if args.prior_body_file is not None:
+        prior = read_text(args.prior_body_file)
+        raw_prefix = next(
+            (
+                prefix
+                for prefix in disclosure_prefixes(disclosure)
+                if body.startswith(prefix)
+            ),
+            None,
+        )
+        if raw_prefix is None or body[len(raw_prefix) :] != prior:
+            errors.append(
+                "candidate is not exactly the disclosure prefix plus the prior body"
+            )
+
+    if args.expected_body_file is not None:
+        expected = read_text(args.expected_body_file)
+        if not matches_candidate(body, expected):
+            errors.append(
+                "stored body does not match the approved candidate, allowing only "
+                "terminal-newline normalization"
+            )
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--kind",
+        choices=tuple(DISCLOSURES),
+        required=True,
+        help="Disclosure text to require.",
+    )
+    body = parser.add_mutually_exclusive_group(required=True)
+    body.add_argument("--body-file", type=Path)
+    body.add_argument(
+        "--body-json-file",
+        type=Path,
+        help="Complete JSON response containing a string-valued body property.",
+    )
+    parser.add_argument(
+        "--prior-body-file",
+        type=Path,
+        help="Require a disclosure-only prefix edit that preserves this body exactly.",
+    )
+    parser.add_argument(
+        "--expected-body-file",
+        type=Path,
+        help=(
+            "Require the body to match this approved candidate, allowing only "
+            "terminal-newline normalization."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        errors = validate(args)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print("LLM disclosure and body preservation checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/python-quality-check/README.md
+++ b/.agents/skills/python-quality-check/README.md
@@ -1,0 +1,11 @@
+# python-quality-check
+
+## Overview
+
+Create and review strict, reproducible uv-managed Python projects.
+
+## Install
+
+```shell
+apm install aoirint/skills/.apm/skills/python-quality-check
+```

--- a/.agents/skills/python-quality-check/SKILL.md
+++ b/.agents/skills/python-quality-check/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: python-quality-check
+description: >-
+  Create, align, or review strict uv-managed installable Python projects hosted
+  on GitHub across packaging, dependency locking, Ruff, mypy, pytest, statement
+  and branch coverage, distribution artifacts, and CI parity. Use for Python
+  applications, libraries, or CLIs with pyproject.toml, .python-version,
+  uv.lock, src/tests layouts, dependency changes, quality-gate adoption,
+  packaging, or GitHub Actions validation; pair with a framework-specific Skill
+  when one applies.
+---
+
+# Python Quality Check
+
+## When to Use
+
+- Use for installable Python applications, libraries, and CLIs managed with uv
+  in GitHub-hosted repositories.
+- Use when establishing or reviewing a repository-wide Python quality baseline.
+- Pair with a framework-specific Skill for framework architecture, lifecycle,
+  UI, protocol, or target-packaging requirements. The stricter applicable
+  requirement wins.
+
+## Goals
+
+- Reproduce the complete Python environment from committed metadata and lock state.
+- Keep first-party APIs, types, tests, coverage, and package boundaries explicit.
+- Make local, CI, distribution, and release evidence describe the same reviewed source.
+- Treat dependency, automation, build, and artifact changes as supply-chain-sensitive.
+
+## Responsibility Boundaries
+
+Use `code-quality-check` for general readability and maintainability,
+`security-check` for dependency provenance, release age, build hooks, secrets,
+and external executables, and `github-workflow` for workflow triggers,
+permissions, runners, action pins, and repository enforcement.
+
+This Skill owns the Python-specific baseline. Framework Skills should add only
+their framework contracts and should not redefine weaker uv, Ruff, typing,
+testing, coverage, or distribution rules.
+
+## Non-Negotiable Baseline
+
+- Use PEP 621 metadata, a real build backend, and a `src/` package layout for an
+  installable project. Do not use `pythonpath = ["src"]` to disguise a package
+  that cannot be installed.
+- Commit `pyproject.toml`, `.python-version`, and `uv.lock`. Pin one development
+  Python minor unless a documented library matrix requires several.
+- Set `[tool.uv] exclude-newer = "P7D"` and review every dependency/lock delta
+  with `security-check`.
+- Put Ruff, mypy, pytest, and pytest-cov in a development dependency group.
+- Run Ruff lint and format checks, strict mypy with unreachable-code warnings,
+  and deterministic pytest through the locked uv environment.
+- Require 100% maintained first-party statement and branch coverage. Do not
+  manufacture compliance with broad omissions, import guards, or execution-only tests.
+- Require keyword arguments from the first project-owned parameter at
+  definitions and call sites. Keep positional parameters only for an evidenced
+  external signature and document the exact exception.
+- Keep local and CI commands equivalent. A check that rewrites `uv.lock` is not
+  valid verification.
+
+## Workflow
+
+1. Inventory the Python contract.
+   - Read repository guidance, `pyproject.toml`, `.python-version`, `uv.lock`,
+     source, tests, scripts, workflows, build metadata, and release configuration.
+   - Record project type, supported Python range, distribution/import/entry-point
+     identities, build backend, dependency groups, and artifact targets.
+   - Mark unavailable facts `blocked`; do not copy values from another project.
+   - Run
+     `uv run --no-config --locked --script <skill-root>/scripts/check_project.py <repository-root>`
+     for the deterministic mechanical floor. Review every finding semantically;
+     a pass does not establish behavior, artifact correctness, or release readiness.
+2. Align project and dependency metadata.
+   - Read [tooling-and-testing.md](references/tooling-and-testing.md) before
+     editing Python metadata, Ruff, mypy, pytest, coverage, or test layout.
+   - Keep runtime dependencies direct and development tools in a development
+     group. Update only intended packages, inspect the full lock delta, then
+     replay with `uv lock --check` and `uv sync --locked --all-groups`.
+3. Align source and API quality.
+   - Keep entry points thin, package imports explicit, and external effects
+     behind typed boundaries.
+   - Apply the keyword-only policy to project-owned functions, methods,
+     dataclasses, factories, and call sites. Keep exceptions narrow and tied to
+     the exact external ABI.
+   - Fix lint and typing findings in code before adding a suppression. Every
+     suppression must name the exact rule/code and a durable local reason.
+4. Align tests and coverage.
+   - Test behavior, state, effects, cleanup, errors, boundaries, and entry points;
+     do not assert only that lines executed.
+   - Inject deterministic seams for clocks, randomness, filesystems, network,
+     subprocesses, and sleeps. Do not hide flakiness with CI retries.
+   - Enforce both statement and branch coverage at 100% for maintained
+     first-party source, while separately recording any genuinely unreachable
+     generated/platform code and its alternative verification.
+5. Align CI and distribution.
+   - Read [ci-and-distribution.md](references/ci-and-distribution.md) before
+     changing workflows, build metadata, wheels, sdists, executables, or releases.
+   - Re-run the complete locked validation on pull requests and on the exact
+     protected integration-branch commit.
+   - Build applicable distributions from a clean reviewed commit. Inspect
+     archive paths, metadata, entry points, contents, permissions, licenses,
+     and absence of secrets, caches, tests, and unrelated development files.
+6. Verify and report.
+   - Run the repository-documented commands, using this default floor when no
+     stronger local command exists:
+
+     ```shell
+     uv lock --check
+     uv sync --locked --all-groups
+     uv run --locked ruff check .
+     uv run --locked ruff format --check .
+     uv run --locked mypy src tests
+     uv run --locked pytest
+     ```
+
+   - Add `uv build`, safe archive inspection with
+     `scripts/inspect_distribution.py`, and clean-environment install/import
+     checks for installable distributions.
+   - Report exact commands/results, dependency review scope, coverage statements
+     and branches, artifact evidence, blockers, and every skipped check.
+
+## Completion Checklist
+
+- Python version, package identity, entry points, build backend, and supported
+  distribution targets are explicit and consistent.
+- uv lock verification and exact sync reproduce the reviewed dependency graph.
+- Ruff lint/format, strict mypy, pytest, and 100% statement/branch coverage pass.
+- First-party APIs are keyword-only except for documented external signatures.
+- Tests establish behavior and failure/cleanup contracts, not line execution alone.
+- CI is lock-preserving and equivalent to documented local checks.
+- Built distributions are inspected as artifacts rather than inferred from source tests.
+- Dependency, automation, and build changes have security/provenance review evidence.

--- a/.agents/skills/python-quality-check/agents/openai.yaml
+++ b/.agents/skills/python-quality-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Quality Check"
+  short_description: "Create or review strict uv-managed Python projects."
+  default_prompt: "Use $python-quality-check to create, align, or review this Python project for locked dependencies, strict tooling, tests, coverage, packaging, and CI parity."

--- a/.agents/skills/python-quality-check/references/ci-and-distribution.md
+++ b/.agents/skills/python-quality-check/references/ci-and-distribution.md
@@ -1,0 +1,94 @@
+# Python CI and Distribution Baseline
+
+## Contents
+
+- [CI parity](#ci-parity)
+- [Event and trust boundaries](#event-and-trust-boundaries)
+- [Distribution verification](#distribution-verification)
+- [Completion evidence](#completion-evidence)
+
+## CI parity
+
+Use `github-workflow` and `security-check` while implementing CI.
+
+- Re-run lock verification, exact sync, Ruff lint, Ruff format, strict mypy,
+  pytest, and coverage from a clean checkout.
+- For a library, run locked pytest on every advertised Python minor. Run the
+  complete lint, format, strict-mypy, coverage, and build gate on the pinned
+  development minor; repeat a gate across the matrix when its result can vary
+  with syntax, typing, dependency markers, native packages, or build output.
+- Clean-install and import the built wheel on every advertised Python minor.
+- Keep CI commands equal to documented local commands. Hidden CI-only flags and
+  local-only shortcuts are findings.
+- Install/select Python from `.python-version` or an explicit matrix consistent
+  with `requires-python`.
+- Pin uv and every external action to reviewed immutable versions. Validate
+  action inputs against the exact pinned version.
+- Bind dependency caches to `uv.lock`, runner, and Python identity. Do not cache
+  `.venv`, secrets, credentials, or signing material.
+- Use repository-owned Composite Actions only for stable same-runner sequences.
+  Keep job runners, permissions, matrices, artifacts, and release gates in workflows.
+
+## Event and trust boundaries
+
+- Validate untrusted changes on `pull_request`, and `merge_group` when required.
+- Re-run the same required validation on the exact protected integration-branch
+  push; do not substitute a prior PR run or API polling.
+- Start permissions at `contents: read`. Do not use `pull_request_target` to
+  execute untrusted proposed source.
+- Keep publication/signing in protected jobs or environments after validation
+  and artifact creation for the same source commit.
+- Use direct `needs` dependencies so build and release consume the complete
+  lint/type/test result and the verified artifact.
+- Run actionlint, applicable ShellCheck, and pinact in addition to Python checks.
+
+## Distribution verification
+
+For installable applications, libraries, or CLIs:
+
+1. Run `uv build` from a clean reviewed commit. `uv.lock` does not by itself
+   lock isolated PEP 517 build requirements: review `[build-system].requires`,
+   constrain build dependencies with reviewed exact bounds or
+   `[tool.uv].build-constraint-dependencies`, and record the resolved build
+   backend/tool versions.
+2. Inspect wheel and sdist paths without extraction by running:
+
+   ```shell
+   uv run --no-config --locked --script \
+     <skill-root>/scripts/inspect_distribution.py dist/<wheel>.whl dist/<sdist>.tar.gz
+   ```
+
+   Reject traversal,
+   unsupported special files, and unexpected executable permissions.
+3. Verify project name/version, metadata, license/notices, package modules,
+   typed markers when promised, entry points, and expected package data.
+4. Reject repository-owned tests, caches, `.env`, credentials, VCS metadata,
+   local paths, development tools, and unrelated files.
+5. For every advertised Python minor, create an environment outside the source
+   tree with `uv venv --python <minor> <environment>`, install the exact wheel
+   with `uv pip install --python <environment-python> dist/<wheel>`, and invoke
+   documented imports and entry points through that interpreter. Do not set
+   `PYTHONPATH` or run from a directory that exposes the source package.
+6. When publishing an sdist, create another clean environment, install the exact
+   sdist so its PEP 517 path builds a wheel, then repeat import/entry checks.
+   Record the resolved runtime and build dependency graphs; neither is implied
+   by the project environment.
+7. Record artifact filename, source commit, Python version, build backend/tool
+   versions, size, SHA-256, and inspection result.
+
+Do not infer artifact correctness from source tests or a successful build
+command. Framework packagers, native extensions, standalone executable tools,
+and platform installers add separate verification surfaces; pair with their
+framework/platform Skill.
+
+## Completion evidence
+
+Report:
+
+- exact local and CI commands and results;
+- supported Python versions and the versions actually exercised;
+- dependency/lock review and any approved exception;
+- statement and branch coverage totals;
+- wheel/sdist contents, clean-environment import/entry checks, and SHA-256;
+- workflow permission/pinning checks;
+- blocked, skipped, or not-applicable branches with concrete reasons.

--- a/.agents/skills/python-quality-check/references/tooling-and-testing.md
+++ b/.agents/skills/python-quality-check/references/tooling-and-testing.md
@@ -1,0 +1,229 @@
+# Python Tooling and Test Baseline
+
+## Contents
+
+- [Project and dependency contract](#project-and-dependency-contract)
+- [Minimum pyproject shape](#minimum-pyproject-shape)
+- [Ruff and keyword-only policy](#ruff-and-keyword-only-policy)
+- [mypy policy](#mypy-policy)
+- [pytest and coverage policy](#pytest-and-coverage-policy)
+- [Locked verification](#locked-verification)
+- [Dependency changes](#dependency-changes)
+
+## Project and dependency contract
+
+- Use PEP 621 `[project]` metadata and a real build backend. Install the `src/`
+  package into the uv environment instead of relying on an injected test path.
+- Keep distribution name, import package, console/module entry points, artifact
+  identity, and version source intentionally mapped.
+- Pin one development Python minor in `.python-version`. Set
+  `requires-python` to the supported range and test every advertised minor.
+- Declare only direct runtime dependencies in `[project].dependencies`. Put
+  Ruff, mypy, pytest, and pytest-cov in `[dependency-groups].dev`.
+- Commit `uv.lock`; treat it as the reviewed graph across supported markers.
+- Set `[tool.uv] exclude-newer = "P7D"`. A narrower exception requires an exact
+  package, reason, approval, and removal/review trigger.
+
+## Minimum pyproject shape
+
+Use repository-confirmed values; never copy placeholders into executable configuration.
+
+```toml
+[project]
+name = "<distribution-name>"
+version = "0.0.0"
+description = "<concise description>"
+readme = "README.md"
+requires-python = ">=<verified-minor>,<next-breaking-minor>"
+dependencies = []
+
+[build-system]
+requires = ["hatchling>=<reviewed-minimum>,<reviewed-upper-bound>"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "mypy>=<reviewed-minimum>,<reviewed-upper-bound>",
+    "pytest>=<reviewed-minimum>,<reviewed-upper-bound>",
+    "pytest-cov>=<reviewed-minimum>,<reviewed-upper-bound>",
+    "ruff>=<reviewed-minimum>,<reviewed-upper-bound>",
+]
+
+[tool.uv]
+exclude-newer = "P7D"
+
+[tool.ruff]
+line-length = 100
+target-version = "<matching-pyNNN>"
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = [
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "F",       # Pyflakes correctness
+    "FBT",     # prevent positional Boolean traps
+    "I",       # deterministic imports
+    "ANN",     # annotations
+    "ARG",     # unused arguments
+    "ASYNC",   # async correctness
+    "B",       # bugbear correctness
+    "C4",      # comprehension clarity
+    "C90",     # explicit complexity ceiling
+    "COM",     # stable comma use
+    "D",       # public documentation
+    "DTZ",     # timezone-aware datetimes
+    "ERA",     # no commented-out code
+    "FLY",     # modern string formatting
+    "G",       # logging format correctness
+    "ICN",     # conventional import names
+    "LOG",     # logging correctness
+    "N",       # naming
+    "PERF",    # avoid ordinary performance traps
+    "PIE",     # miscellaneous correctness
+    "PL",      # maintainability and correctness
+    # Preview rule selected by exact code: reject every project-owned positional parameter.
+    "PLR0917",
+    "PT",      # pytest style
+    "PTH",     # pathlib boundaries
+    "RET",     # return-path clarity
+    "RUF",     # Ruff-specific correctness
+    "S",       # common security mistakes
+    "SIM",     # needless control-flow complexity
+    "SLF",     # private-member boundary violations
+    "T20",     # stray print/pprint
+    "TRY",     # exception design
+    "UP",      # syntax modernization
+]
+ignore = [
+    "COM812",  # Ruff formatter owns trailing comma layout.
+    "D203",    # Select D211: no blank line before class docstrings.
+    "D213",    # Select D212: summary starts on the first line.
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-positional-args = 0
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]  # pytest assertions are the test oracle.
+
+[tool.mypy]
+files = ["src", "tests"]
+strict = true
+warn_unreachable = true
+warn_unused_configs = true
+show_error_code_links = true
+
+[tool.pytest.ini_options]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+    "-ra",
+    "--cov=<package>",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-fail-under=100",
+]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source_pkgs = ["<package>"]
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+skip_covered = false
+```
+
+Verify option names against the locked tool versions. A library supporting
+multiple Python minors needs an explicit test matrix; do not weaken the
+configured development target.
+
+## Ruff and keyword-only policy
+
+- Run both `ruff check` and `ruff format --check`.
+- Use a reasoned selected rule set rather than `ALL`. Treat configuration
+  warnings as failures.
+- Keep every `[tool.ruff.lint].select` entry on its own line with a concise
+  rationale comment. Preserve those comments when reordering, extracting, or
+  deploying this baseline; add or update the rationale in the same change as a
+  rule selection change.
+- Fix code first. A file or line suppression must name the exact rule and give
+  a durable reason at the suppression site.
+- Require keyword arguments at first-party definitions and call sites,
+  including a sole input. Put `*` before the first project-owned parameter;
+  `self` and `cls` remain implicit receivers.
+- Use `kw_only=True` for project-owned dataclasses. Do not introduce
+  `NamedTuple`, `namedtuple`, positional generated constructors, or `*args` to
+  evade the policy.
+- Give project-owned lambdas keyword-only parameters. Use a named function with
+  an evidenced exception when an external callback requires a positional lambda
+  signature.
+- Select `PLR0917` explicitly with `max-positional-args = 0`. Do not suppress
+  `PLR0917`, `PL`, or `ALL` globally.
+- Limit Ruff source exclusions to generated APM/deployment/worktree roots. Do
+  not exclude `src`, `tests`, `scripts`, tools, examples, or migrations from
+  the repository-wide `ruff check .`.
+- Preserve a positional signature only when an external ABI requires it.
+  Document the exact contract on the definition line with
+  `keyword-only-exception:` and a narrow `noqa` when Ruff requires one.
+- Prefer keywords at first-party call sites even when a compatibility
+  definition must accept positional calls.
+
+## mypy policy
+
+- Check maintained source and tests with `strict = true` and
+  `warn_unreachable = true`.
+- Do not enable global `ignore_missing_imports`, skip imports, or ignore errors.
+- Contain untyped dependencies in one adapter and validate/narrow values before
+  returning typed results.
+- A `type: ignore[code]` must name the code and explain the proven typing
+  boundary. Remove it when the dependency or seam changes.
+- Type callbacks, coroutine results, task handles, serialized values, schemas,
+  factories, and public package surfaces.
+
+## pytest and coverage policy
+
+- Require 100% statement and branch coverage for maintained first-party source.
+- Do not use broad omit rules, `pragma: no cover`, or import guards to
+  manufacture 100%.
+- Test module and console entry points without launching work at import time.
+- Fail on unknown markers/configuration and make clock, randomness, sleep,
+  filesystem, subprocess, and network behavior deterministic through seams.
+- Assert state, declared effects, boundary calls, failures, cleanup, and
+  user-observable outcomes; executing a line is not a sufficient assertion.
+- Keep ordinary tests offline and independent of user credentials.
+- Organize tests around contracts: domain values, application transitions,
+  presentation mapping, infrastructure boundaries, composition, entry points,
+  and artifact smoke behavior. Source-file mirroring alone is insufficient.
+
+## Locked verification
+
+Run from a clean repository root:
+
+```shell
+uv lock --check
+uv sync --locked --all-groups
+uv run --locked ruff check .
+uv run --locked ruff format --check .
+uv run --locked mypy src tests
+uv run --locked pytest
+```
+
+Run `uv build` when the project is an installable distribution. Do not use bare
+`pip install`, globally installed checkers, or unlocked `uv run` as release evidence.
+
+## Dependency changes
+
+1. Invoke `security-check` before resolution.
+2. Record purpose, source/publisher, license, constraint, release age,
+   transitive changes, binary/build hooks, runtime behavior, and platform support.
+3. Update only the intended package, using `uv lock --upgrade-package` when appropriate.
+4. Review `pyproject.toml` and the complete `uv.lock` delta.
+5. Replay exact sync and the complete locked verification set.

--- a/.agents/skills/python-quality-check/scripts/check_project.py
+++ b/.agents/skills/python-quality-check/scripts/check_project.py
@@ -1,0 +1,895 @@
+# /// script
+# requires-python = ">=3.11,<3.15"
+# dependencies = []
+# [tool.uv]
+# exclude-newer = "P7D"
+# ///
+"""Check the mechanical floor of a uv-managed Python repository without modifying it."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import json
+import re
+import sys
+import tokenize
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+REQUIRED_FILES = (
+    "pyproject.toml",
+    ".python-version",
+    "uv.lock",
+    "README.md",
+)
+REQUIRED_DEV_DEPENDENCIES = {"mypy", "pytest", "pytest-cov", "ruff"}
+REQUIRED_RUFF_FAMILIES = {
+    "ANN",
+    "ASYNC",
+    "B",
+    "C90",
+    "E",
+    "F",
+    "FBT",
+    "I",
+    "PL",
+    "PLR0917",
+    "PT",
+    "RUF",
+    "S",
+    "TRY",
+    "UP",
+    "W",
+}
+REQUIRED_CI_COMMANDS = (
+    "uv lock --check",
+    "uv sync --locked --all-groups",
+    "uv run --locked ruff check",
+    "uv run --locked ruff format --check",
+    "uv run --locked mypy",
+    "uv run --locked pytest",
+)
+TOP_LEVEL_EXCLUDED_PYTHON_PARTS = {
+    ".agents",
+    ".git",
+    "apm_modules",
+}
+NESTED_EXCLUDED_PYTHON_PARTS = {
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "site-packages",
+}
+ALLOWED_RUFF_EXCLUDE_PATHS = {
+    ".agents/skills",
+    ".agents/worktrees",
+    "apm_modules",
+}
+RECEIVER_PRESERVING_DECORATOR_PATHS = {
+    "abc.abstractmethod",
+    "builtins.property",
+    "functools.cache",
+    "functools.cached_property",
+    "functools.lru_cache",
+    "property",
+    "typing.override",
+    "typing_extensions.override",
+}
+IMPLICIT_CLASS_RECEIVER_METHODS = {
+    "__class_getitem__",
+    "__init_subclass__",
+    "__new__",
+}
+PROTECTED_POSITIONAL_POLICY_PATHS = RECEIVER_PRESERVING_DECORATOR_PATHS | {
+    "builtins.classmethod",
+    "builtins.staticmethod",
+    "classmethod",
+    "collections.namedtuple",
+    "dataclasses.dataclass",
+    "dataclasses.field",
+    "dataclasses.make_dataclass",
+    "staticmethod",
+    "typing.NamedTuple",
+}
+USES_PATTERN = re.compile(r"""\buses:\s*["']?([^\s#"']+)""")
+KEYWORD_ONLY_EXCEPTION_PATTERN = re.compile(
+    r"^#\s*(?:noqa:\s*PLR0917\s*--\s*)?keyword-only-exception:\s*"
+    r"(?P<reason>\S(?:.*\S)?)\s*$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One mechanical baseline violation."""
+
+    code: str
+    path: str
+    message: str
+
+
+class Checker:
+    """Collect deterministic repository findings."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.findings: list[Finding] = []
+
+    def add(self, code: str, path: str, message: str) -> None:
+        """Record a finding."""
+        self.findings.append(Finding(code, path, message))
+
+    def require(self, condition: bool, code: str, path: str, message: str) -> None:
+        """Record a finding unless a condition holds."""
+        if not condition:
+            self.add(code, path, message)
+
+    def run(self) -> list[Finding]:
+        """Run all mechanical checks."""
+        for relative in REQUIRED_FILES:
+            self.require(
+                (self.root / relative).is_file(),
+                "required-file",
+                relative,
+                "required baseline file is missing",
+            )
+
+        pyproject_path = self.root / "pyproject.toml"
+        if pyproject_path.is_file():
+            self._check_pyproject(pyproject_path)
+        self._check_python_layout()
+        self._check_workflows()
+        return sorted(
+            self.findings, key=lambda item: (item.path, item.code, item.message)
+        )
+
+    def _check_pyproject(self, path: Path) -> None:
+        try:
+            document = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+            self.add("invalid-pyproject", "pyproject.toml", f"cannot parse TOML: {exc}")
+            return
+
+        project = _table(document, "project")
+        self.require(
+            bool(project.get("name")),
+            "project-name",
+            "pyproject.toml",
+            "project.name is required",
+        )
+        self.require(
+            bool(project.get("description"))
+            and project.get("description") != "Add your description here",
+            "project-description",
+            "pyproject.toml",
+            "project.description must be intentional, not a generated placeholder",
+        )
+        self.require(
+            bool(project.get("requires-python")),
+            "requires-python",
+            "pyproject.toml",
+            "project.requires-python must define the supported range",
+        )
+
+        dev_groups = _table(document, "dependency-groups")
+        dev = {_dependency_name(value) for value in _string_list(dev_groups.get("dev"))}
+        missing_dev = sorted(REQUIRED_DEV_DEPENDENCIES - dev)
+        self.require(
+            not missing_dev,
+            "dev-dependencies",
+            "pyproject.toml",
+            f"dependency-groups.dev is missing: {', '.join(missing_dev)}",
+        )
+
+        tool = _table(document, "tool")
+        uv = _table(tool, "uv")
+        self.require(
+            uv.get("exclude-newer") == "P7D",
+            "uv-cooldown",
+            "pyproject.toml",
+            'tool.uv.exclude-newer must equal "P7D"',
+        )
+
+        ruff = _table(tool, "ruff")
+        self.require(
+            bool(ruff.get("target-version")),
+            "ruff-target",
+            "pyproject.toml",
+            "tool.ruff.target-version is required",
+        )
+        ruff_lint = _table(ruff, "lint")
+        selected = set(_string_list(ruff_lint.get("select")))
+        missing_families = sorted(REQUIRED_RUFF_FAMILIES - selected)
+        self.require(
+            not missing_families,
+            "ruff-families",
+            "pyproject.toml",
+            f"Ruff minimum families are missing: {', '.join(missing_families)}",
+        )
+        self.require(
+            ruff_lint.get("preview") is True,
+            "ruff-preview",
+            "pyproject.toml",
+            "tool.ruff.lint.preview must be true for PLR0917",
+        )
+        self.require(
+            ruff_lint.get("explicit-preview-rules") is True,
+            "ruff-explicit-preview",
+            "pyproject.toml",
+            "tool.ruff.lint.explicit-preview-rules must be true",
+        )
+        ruff_pylint = _table(ruff_lint, "pylint")
+        max_positional_args = ruff_pylint.get("max-positional-args")
+        self.require(
+            type(max_positional_args) is int and max_positional_args == 0,
+            "ruff-positional-arguments",
+            "pyproject.toml",
+            "tool.ruff.lint.pylint.max-positional-args must equal 0",
+        )
+        ignored_selectors = {
+            selector.upper()
+            for key in ("ignore", "extend-ignore")
+            for selector in _string_list(ruff_lint.get(key))
+        }
+        for key in ("per-file-ignores", "extend-per-file-ignores"):
+            per_file_ignores = _table(ruff_lint, key)
+            ignored_selectors.update(
+                selector.upper()
+                for selectors in per_file_ignores.values()
+                for selector in _string_list(selectors)
+            )
+        self.require(
+            not any(
+                selector == "ALL" or "PLR0917".startswith(selector)
+                for selector in ignored_selectors
+            ),
+            "ruff-positional-arguments-suppression",
+            "pyproject.toml",
+            "PLR0917 must not be suppressed globally or through per-file ignores",
+        )
+        ruff_excludes = {
+            _normalize_ruff_exclude(pattern)
+            for value in (
+                ruff.get("exclude"),
+                ruff.get("extend-exclude"),
+                ruff_lint.get("exclude"),
+            )
+            for pattern in _string_list(value)
+        }
+        self.require(
+            ruff_excludes <= ALLOWED_RUFF_EXCLUDE_PATHS,
+            "ruff-owned-source-exclusion",
+            "pyproject.toml",
+            "Ruff exclusions may contain only generated APM or agent-worktree paths",
+        )
+
+        mypy = _table(tool, "mypy")
+        self.require(
+            mypy.get("strict") is True,
+            "mypy-strict",
+            "pyproject.toml",
+            "tool.mypy.strict must be true",
+        )
+        self.require(
+            mypy.get("warn_unreachable") is True,
+            "mypy-unreachable",
+            "pyproject.toml",
+            "tool.mypy.warn_unreachable must be true",
+        )
+        mypy_files = set(_string_list(mypy.get("files")))
+        self.require(
+            {"src", "tests"}.issubset(mypy_files),
+            "mypy-scope",
+            "pyproject.toml",
+            'tool.mypy.files must include "src" and "tests"',
+        )
+
+        pytest = _table(tool, "pytest")
+        pytest_options = _table(pytest, "ini_options")
+        addopts = " ".join(_string_list(pytest_options.get("addopts")))
+        for token in (
+            "--strict-config",
+            "--strict-markers",
+            "--cov-branch",
+            "--cov-fail-under=100",
+        ):
+            self.require(
+                token in addopts,
+                "pytest-option",
+                "pyproject.toml",
+                f"pytest addopts must contain {token}",
+            )
+        self.require(
+            re.search(r"(?:^|\s)--cov=[^\s]+", addopts) is not None,
+            "coverage-source",
+            "pyproject.toml",
+            "pytest addopts must name the owned package with --cov=<package>",
+        )
+
+        coverage = _table(tool, "coverage")
+        coverage_run = _table(coverage, "run")
+        self.require(
+            coverage_run.get("branch") is True,
+            "coverage-branch",
+            "pyproject.toml",
+            "tool.coverage.run.branch must be true",
+        )
+        source_scope = _string_list(coverage_run.get("source")) + _string_list(
+            coverage_run.get("source_pkgs")
+        )
+        self.require(
+            bool(source_scope),
+            "coverage-scope",
+            "pyproject.toml",
+            "coverage must name owned source/package scope",
+        )
+        coverage_report = _table(coverage, "report")
+        self.require(
+            coverage_report.get("fail_under") == 100,
+            "coverage-threshold",
+            "pyproject.toml",
+            "tool.coverage.report.fail_under must equal 100",
+        )
+        self.require(
+            coverage_report.get("show_missing") is True,
+            "coverage-missing",
+            "pyproject.toml",
+            "tool.coverage.report.show_missing must be true",
+        )
+
+    def _check_python_layout(self) -> None:
+        src = self.root / "src"
+        tests = self.root / "tests"
+        self.require(
+            any(src.rglob("*.py")) if src.is_dir() else False,
+            "src-layout",
+            "src",
+            "src must contain Python source",
+        )
+        self.require(
+            any(tests.rglob("test_*.py")) if tests.is_dir() else False,
+            "test-layout",
+            "tests",
+            "tests must contain pytest modules",
+        )
+
+        for file in self.root.rglob("*.py"):
+            relative_parts = file.relative_to(self.root).parts
+            if not _python_file_is_excluded(relative_parts):
+                self._check_keyword_only_definitions(file)
+
+    def _check_keyword_only_definitions(self, file: Path) -> None:
+        relative = file.relative_to(self.root).as_posix()
+        try:
+            text = file.read_text(encoding="utf-8")
+            tree = ast.parse(text, filename=relative)
+        except SyntaxError as exc:
+            self.add(
+                "invalid-python",
+                f"{relative}:{exc.lineno or 1}",
+                f"cannot parse Python while checking API policy: {exc.msg}",
+            )
+            return
+        except (OSError, UnicodeError) as exc:
+            self.add(
+                "unreadable-python",
+                relative,
+                f"cannot read Python while checking API policy: {exc}",
+            )
+            return
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+        comments = _comments_by_line(text)
+        import_aliases = _import_aliases(tree)
+        for node in ast.walk(tree):
+            alias_value = _assignment_value(node)
+            if (
+                alias_value is not None
+                and _resolved_path(
+                    alias_value,
+                    import_aliases=import_aliases,
+                )
+                in PROTECTED_POSITIONAL_POLICY_PATHS
+            ):
+                self.add(
+                    "keyword-only-callable-alias",
+                    f"{relative}:{node.lineno}",
+                    "use the standard decorator or constructor directly instead of an "
+                    "assignment alias",
+                )
+                continue
+            if isinstance(node, ast.Lambda):
+                if (
+                    node.args.posonlyargs
+                    or node.args.args
+                    or node.args.vararg is not None
+                ):
+                    self.add(
+                        "keyword-only-lambda",
+                        f"{relative}:{node.lineno}",
+                        "make lambda parameters keyword-only with 'lambda *, ...' or use a "
+                        "named definition for an external-signature exception",
+                    )
+                continue
+            if isinstance(node, ast.ClassDef):
+                dataclass_decorator = _dataclass_decorator(
+                    node=node,
+                    import_aliases=import_aliases,
+                )
+                if dataclass_decorator is not None and not _dataclass_is_keyword_only(
+                    dataclass_decorator
+                ):
+                    self.add(
+                        "keyword-only-dataclass",
+                        f"{relative}:{node.lineno}",
+                        "define project-owned dataclasses with dataclass(kw_only=True)",
+                    )
+                if dataclass_decorator is not None and _dataclass_has_positional_field(
+                    node=node,
+                    import_aliases=import_aliases,
+                ):
+                    self.add(
+                        "keyword-only-dataclass-field",
+                        f"{relative}:{node.lineno}",
+                        "remove field(kw_only=False) from keyword-only dataclasses",
+                    )
+                if any(
+                    _resolved_path(base, import_aliases=import_aliases)
+                    == "typing.NamedTuple"
+                    for base in node.bases
+                ):
+                    self.add(
+                        "keyword-only-generated-constructor",
+                        f"{relative}:{node.lineno}",
+                        "replace project-owned NamedTuple positional construction with a "
+                        "keyword-only value type",
+                    )
+                continue
+            if isinstance(node, ast.Call) and _resolved_path(
+                node.func,
+                import_aliases=import_aliases,
+            ) in {
+                "collections.namedtuple",
+                "dataclasses.make_dataclass",
+                "typing.NamedTuple",
+            }:
+                self.add(
+                    "keyword-only-generated-constructor",
+                    f"{relative}:{node.lineno}",
+                    "replace generated project-owned positional construction with a "
+                    "keyword-only value type",
+                )
+                continue
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            positional = [*node.args.posonlyargs, *node.args.args]
+            if positional and _is_implicit_receiver(
+                node=node,
+                parent=parents.get(node),
+                parameter=positional[0],
+                import_aliases=import_aliases,
+            ):
+                positional = positional[1:]
+            if not positional and node.args.vararg is None:
+                continue
+            exception = KEYWORD_ONLY_EXCEPTION_PATTERN.fullmatch(
+                comments.get(node.lineno, "")
+            )
+            if exception is not None and len(exception.group("reason")) >= 8:
+                continue
+            self.add(
+                "keyword-only-definition",
+                f"{relative}:{node.lineno}",
+                "make the first project-owned parameter keyword-only with '*' or document a "
+                "narrow external-signature exception",
+            )
+
+    def _check_workflows(self) -> None:
+        workflow_root = self.root / ".github" / "workflows"
+        workflows = (
+            sorted((*workflow_root.glob("*.yml"), *workflow_root.glob("*.yaml")))
+            if workflow_root.is_dir()
+            else []
+        )
+        self.require(
+            bool(workflows),
+            "ci-workflow",
+            ".github/workflows",
+            "at least one GitHub Actions workflow is required",
+        )
+        if not workflows:
+            return
+        workflow_text = "\n".join(
+            path.read_text(encoding="utf-8") for path in workflows
+        )
+        ci_files = self._collect_ci_files(workflows)
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in ci_files)
+        for command in REQUIRED_CI_COMMANDS:
+            self.require(
+                command in combined,
+                "ci-command",
+                ".github/workflows",
+                f"workflow must run: {command}",
+            )
+        self.require(
+            re.search(r"(?m)^permissions:\s*\n\s+contents:\s*read\s*$", workflow_text)
+            is not None,
+            "ci-permissions",
+            ".github/workflows",
+            "workflow permissions must include contents: read",
+        )
+        self.require(
+            "persist-credentials: false" in workflow_text,
+            "checkout-credentials",
+            ".github/workflows",
+            "checkout must disable persisted credentials",
+        )
+        self.require(
+            "timeout-minutes:" in workflow_text,
+            "ci-timeout",
+            ".github/workflows",
+            "jobs must have an explicit timeout",
+        )
+        for path in ci_files:
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1
+            ):
+                match = USES_PATTERN.search(line)
+                if match is None or match.group(1).startswith("./"):
+                    continue
+                value = match.group(1)
+                if re.fullmatch(r"[^@]+@[0-9a-fA-F]{40}", value) is None:
+                    self.add(
+                        "action-pin",
+                        f"{path.relative_to(self.root).as_posix()}:{line_number}",
+                        "external action/reusable workflow must use a full commit SHA",
+                    )
+
+    def _collect_ci_files(self, workflows: list[Path]) -> list[Path]:
+        """Follow repository-local actions and reusable workflows from CI roots."""
+        repository_root = self.root.resolve()
+        pending = list(reversed(workflows))
+        collected: list[Path] = []
+        seen: set[Path] = set()
+        while pending:
+            path = pending.pop().resolve()
+            if path in seen:
+                continue
+            seen.add(path)
+            collected.append(path)
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1
+            ):
+                match = USES_PATTERN.search(line)
+                if match is None or not match.group(1).startswith("./"):
+                    continue
+                referenced = (repository_root / match.group(1)[2:]).resolve()
+                relative_source = path.relative_to(repository_root).as_posix()
+                if not referenced.is_relative_to(repository_root):
+                    self.add(
+                        "local-action-path",
+                        f"{relative_source}:{line_number}",
+                        "repository-local action/workflow reference escapes the repository",
+                    )
+                    continue
+                target = _resolve_local_ci_file(referenced)
+                if target is None:
+                    self.add(
+                        "local-action-missing",
+                        f"{relative_source}:{line_number}",
+                        f"repository-local action/workflow does not resolve: {match.group(1)}",
+                    )
+                    continue
+                target = target.resolve()
+                if not target.is_relative_to(repository_root):
+                    self.add(
+                        "local-action-path",
+                        f"{relative_source}:{line_number}",
+                        "repository-local action/workflow resolves outside the repository",
+                    )
+                    continue
+                if target not in seen:
+                    pending.append(target)
+        return collected
+
+
+def _table(value: dict[str, Any], key: str) -> dict[str, Any]:
+    child = value.get(key)
+    return child if isinstance(child, dict) else {}
+
+
+def _resolve_local_ci_file(path: Path) -> Path | None:
+    if path.is_file() and path.suffix in {".yaml", ".yml"}:
+        return path
+    if not path.is_dir():
+        return None
+    for name in ("action.yml", "action.yaml"):
+        candidate = path / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _dependency_name(requirement: str) -> str:
+    match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", requirement.strip())
+    return match.group(0).lower().replace("_", "-") if match else ""
+
+
+def _comments_by_line(text: str) -> dict[int, str]:
+    return {
+        token.start[0]: token.string
+        for token in tokenize.generate_tokens(io.StringIO(text).readline)
+        if token.type == tokenize.COMMENT
+    }
+
+
+def _is_implicit_receiver(
+    *,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    parent: ast.AST | None,
+    parameter: ast.arg,
+    import_aliases: dict[str, str],
+) -> bool:
+    if not isinstance(parent, ast.ClassDef):
+        return False
+    decorator_paths = {
+        _resolved_path(decorator, import_aliases=import_aliases)
+        for decorator in node.decorator_list
+    }
+    staticmethod_paths = {"staticmethod", "builtins.staticmethod"}
+    classmethod_paths = {"classmethod", "builtins.classmethod"}
+    property_decorators = {
+        f"{node.name}.deleter",
+        f"{node.name}.getter",
+        f"{node.name}.setter",
+    }
+    class_bound_names = {
+        name
+        for statement in parent.body
+        if statement is not node
+        for name in _bound_names(statement)
+    }
+    if any(
+        path not in property_decorators and path.partition(".")[0] in class_bound_names
+        for path in decorator_paths
+    ):
+        return False
+    known_decorators = (
+        RECEIVER_PRESERVING_DECORATOR_PATHS
+        | property_decorators
+        | staticmethod_paths
+        | classmethod_paths
+    )
+    if not decorator_paths <= known_decorators:
+        return False
+    if decorator_paths & staticmethod_paths:
+        return False
+    if node.name in IMPLICIT_CLASS_RECEIVER_METHODS:
+        return parameter.arg == "cls"
+    if decorator_paths & classmethod_paths:
+        return parameter.arg == "cls"
+    if parameter.arg != "self":
+        return False
+    return decorator_paths <= RECEIVER_PRESERVING_DECORATOR_PATHS | property_decorators
+
+
+def _decorator_path(decorator: ast.expr) -> str:
+    if isinstance(decorator, ast.Call):
+        return _decorator_path(decorator.func)
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    if isinstance(decorator, ast.Attribute):
+        prefix = _decorator_path(decorator.value)
+        return f"{prefix}.{decorator.attr}" if prefix else decorator.attr
+    return ""
+
+
+def _dataclass_decorator(
+    *,
+    node: ast.ClassDef,
+    import_aliases: dict[str, str],
+) -> ast.expr | None:
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if (
+            _resolved_path(target, import_aliases=import_aliases)
+            == "dataclasses.dataclass"
+        ):
+            return decorator
+    return None
+
+
+def _dataclass_is_keyword_only(decorator: ast.expr) -> bool:
+    if not isinstance(decorator, ast.Call):
+        return False
+    return any(
+        keyword.arg == "kw_only"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is True
+        for keyword in decorator.keywords
+    )
+
+
+def _dataclass_has_positional_field(
+    *,
+    node: ast.ClassDef,
+    import_aliases: dict[str, str],
+) -> bool:
+    for statement in node.body:
+        if not isinstance(statement, ast.AnnAssign) or not isinstance(
+            statement.value, ast.Call
+        ):
+            continue
+        if (
+            _resolved_path(statement.value.func, import_aliases=import_aliases)
+            != "dataclasses.field"
+        ):
+            continue
+        if any(
+            keyword.arg == "kw_only"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is False
+            for keyword in statement.value.keywords
+        ):
+            return True
+    return False
+
+
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    candidates: dict[str, set[str]] = {}
+    for statement in _module_scope_statements(tree):
+        if isinstance(statement, ast.ImportFrom) and statement.module is not None:
+            for imported in statement.names:
+                candidates.setdefault(imported.asname or imported.name, set()).add(
+                    f"{statement.module}.{imported.name}"
+                )
+        elif isinstance(statement, ast.Import):
+            for imported in statement.names:
+                candidates.setdefault(imported.asname or imported.name, set()).add(
+                    imported.name
+                )
+        else:
+            for name in _bound_names(statement):
+                candidates.setdefault(name, set()).add("<shadowed>")
+    return {
+        name: next(iter(paths)) if len(paths) == 1 else "<shadowed>"
+        for name, paths in candidates.items()
+    }
+
+
+def _module_scope_statements(tree: ast.Module) -> list[ast.stmt]:
+    statements: list[ast.stmt] = []
+    pending = list(reversed(tree.body))
+    while pending:
+        statement = pending.pop()
+        statements.append(statement)
+        if isinstance(statement, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        children = [
+            child
+            for child in ast.iter_child_nodes(statement)
+            if isinstance(child, ast.stmt)
+        ]
+        pending.extend(reversed(children))
+    return statements
+
+
+def _bound_names(statement: ast.stmt) -> set[str]:
+    if isinstance(statement, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        return {statement.name}
+    if isinstance(statement, ast.ImportFrom):
+        return {imported.asname or imported.name for imported in statement.names}
+    if isinstance(statement, ast.Import):
+        return {
+            imported.asname or imported.name.partition(".")[0]
+            for imported in statement.names
+        }
+    targets: list[ast.expr] = []
+    if isinstance(statement, ast.Assign):
+        targets.extend(statement.targets)
+    elif isinstance(statement, (ast.AnnAssign, ast.AugAssign)):
+        targets.append(statement.target)
+    elif isinstance(statement, (ast.For, ast.AsyncFor)):
+        targets.append(statement.target)
+    elif isinstance(statement, (ast.With, ast.AsyncWith)):
+        targets.extend(
+            item.optional_vars for item in statement.items if item.optional_vars
+        )
+    return {
+        node.id
+        for target in targets
+        for node in ast.walk(target)
+        if isinstance(node, ast.Name)
+    }
+
+
+def _resolved_path(expression: ast.expr, *, import_aliases: dict[str, str]) -> str:
+    path = _decorator_path(expression)
+    first, separator, remainder = path.partition(".")
+    resolved_first = import_aliases.get(first, first)
+    return f"{resolved_first}.{remainder}" if separator else resolved_first
+
+
+def _python_file_is_excluded(relative_parts: tuple[str, ...]) -> bool:
+    if relative_parts[0] in TOP_LEVEL_EXCLUDED_PYTHON_PARTS:
+        return True
+    if not NESTED_EXCLUDED_PYTHON_PARTS.isdisjoint(relative_parts):
+        return True
+    return relative_parts[0] != "src" and any(
+        part in {"build", "dist"} for part in relative_parts[:-1]
+    )
+
+
+def _normalize_ruff_exclude(pattern: str) -> str:
+    normalized = pattern.replace("\\", "/").strip("/")
+    return normalized.removesuffix("/**").rstrip("/")
+
+
+def _assignment_value(node: ast.AST) -> ast.expr | None:
+    if (
+        isinstance(node, ast.Assign)
+        and all(isinstance(target, ast.Name) for target in node.targets)
+        and isinstance(node.value, (ast.Name, ast.Attribute))
+    ):
+        return node.value
+    if (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and isinstance(node.value, (ast.Name, ast.Attribute))
+    ):
+        return node.value
+    return None
+
+
+def main() -> int:
+    """Run the command-line checker."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path, help="uv-managed Python repository root")
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON"
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    if not root.is_dir():
+        parser.error(f"not a directory: {root}")
+
+    findings = Checker(root).run()
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "status": "PASS" if not findings else "FAIL",
+                    "findings": [asdict(item) for item in findings],
+                },
+                indent=2,
+            )
+        )
+    elif findings:
+        for finding in findings:
+            print(f"{finding.path}: [{finding.code}] {finding.message}")
+        print(f"FAIL: {len(findings)} finding(s)")
+    else:
+        print("PASS: mechanical Python project baseline satisfied")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/python-quality-check/scripts/check_project.py.lock
+++ b/.agents/skills/python-quality-check/scripts/check_project.py.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.15"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"

--- a/.agents/skills/python-quality-check/scripts/inspect_distribution.py
+++ b/.agents/skills/python-quality-check/scripts/inspect_distribution.py
@@ -1,0 +1,175 @@
+# /// script
+# requires-python = ">=3.11,<3.15"
+# dependencies = []
+# [tool.uv]
+# exclude-newer = "P7D"
+# ///
+"""Safely inspect wheel and sdist archive paths, types, modes, size, and SHA-256."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+import tarfile
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One archive-floor violation."""
+
+    archive: str
+    member: str
+    code: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class Result:
+    """Inspection result for one distribution archive."""
+
+    archive: str
+    size: int
+    sha256: str
+    members: int
+    findings: tuple[Finding, ...]
+
+
+def _path_finding(*, archive: Path, member: str) -> Finding | None:
+    normalized = PurePosixPath(member)
+    if "\\" in member:
+        return Finding(
+            archive.name,
+            member,
+            "non-posix-path",
+            "archive member path contains a backslash",
+        )
+    if normalized.is_absolute() or ".." in normalized.parts:
+        return Finding(
+            archive.name,
+            member,
+            "unsafe-path",
+            "archive member path is absolute or traverses a parent",
+        )
+    if not normalized.parts or normalized == PurePosixPath("."):
+        return Finding(
+            archive.name,
+            member,
+            "empty-path",
+            "archive member path is empty",
+        )
+    return None
+
+
+def _inspect_zip(archive: Path) -> tuple[int, list[Finding]]:
+    findings: list[Finding] = []
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        for item in members:
+            path_finding = _path_finding(archive=archive, member=item.filename)
+            if path_finding is not None:
+                findings.append(path_finding)
+            mode = item.external_attr >> 16
+            file_type = stat.S_IFMT(mode)
+            if mode and file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                findings.append(
+                    Finding(
+                        archive.name,
+                        item.filename,
+                        "special-file",
+                        "wheel contains a link or unsupported special file",
+                    )
+                )
+            if (
+                not item.is_dir()
+                and mode
+                and mode & 0o111
+                and ".data/scripts/" not in item.filename
+            ):
+                findings.append(
+                    Finding(
+                        archive.name,
+                        item.filename,
+                        "unexpected-executable",
+                        "wheel member is executable outside the scripts directory",
+                    )
+                )
+    return len(members), findings
+
+
+def _inspect_tar(archive: Path) -> tuple[int, list[Finding]]:
+    findings: list[Finding] = []
+    with tarfile.open(archive, mode="r:*") as bundle:
+        members = bundle.getmembers()
+        for item in members:
+            path_finding = _path_finding(archive=archive, member=item.name)
+            if path_finding is not None:
+                findings.append(path_finding)
+            if not (item.isfile() or item.isdir()):
+                findings.append(
+                    Finding(
+                        archive.name,
+                        item.name,
+                        "special-file",
+                        "sdist contains a link or unsupported special file",
+                    )
+                )
+            if item.isfile() and item.mode & 0o111:
+                findings.append(
+                    Finding(
+                        archive.name,
+                        item.name,
+                        "unexpected-executable",
+                        "sdist member has an executable mode",
+                    )
+                )
+    return len(members), findings
+
+
+def inspect(archive: Path) -> Result:
+    """Inspect one archive without extracting it."""
+    archive = archive.resolve()
+    if not archive.is_file():
+        raise FileNotFoundError(archive)
+    if archive.suffix == ".whl":
+        members, findings = _inspect_zip(archive)
+    elif archive.name.endswith((".tar.gz", ".tar.bz2", ".tar.xz")):
+        members, findings = _inspect_tar(archive)
+    else:
+        raise ValueError(f"unsupported distribution archive: {archive.name}")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    return Result(
+        archive=archive.name,
+        size=archive.stat().st_size,
+        sha256=digest,
+        members=members,
+        findings=tuple(findings),
+    )
+
+
+def main() -> int:
+    """Run distribution inspection."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archives", nargs="+", type=Path)
+    args = parser.parse_args()
+    try:
+        results = [inspect(archive) for archive in args.archives]
+    except (
+        FileNotFoundError,
+        OSError,
+        ValueError,
+        tarfile.TarError,
+        zipfile.BadZipFile,
+    ) as exc:
+        parser.error(str(exc))
+    print(json.dumps([asdict(result) for result in results], indent=2))
+    return 1 if any(result.findings for result in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/python-quality-check/scripts/inspect_distribution.py.lock
+++ b/.agents/skills/python-quality-check/scripts/inspect_distribution.py.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.15"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"

--- a/.agents/skills/python-quality-check/scripts/test_check_project.py
+++ b/.agents/skills/python-quality-check/scripts/test_check_project.py
@@ -1,0 +1,417 @@
+"""Regression tests for the shared Python project mechanical checker."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_project import Checker
+
+
+class KeywordOnlyCheckerTests(unittest.TestCase):
+    """Exercise zero-positional enforcement and its narrow exceptions."""
+
+    def findings_for_source(self, *, source: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_file = root / "src" / "package" / "module.py"
+            source_file.parent.mkdir(parents=True)
+            source_file.write_text(source, encoding="utf-8")
+            checker = Checker(root)
+            checker._check_keyword_only_definitions(source_file)
+            return [finding.code for finding in checker.findings]
+
+    def test_generic_checker_does_not_require_flet(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pyproject = root / "pyproject.toml"
+            pyproject.write_text(
+                """
+[project]
+name = "example"
+version = "1.0.0"
+description = "Example library"
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""",
+                encoding="utf-8",
+            )
+            checker = Checker(root)
+            checker._check_pyproject(pyproject)
+            codes = {finding.code for finding in checker.findings}
+            self.assertNotIn("flet-dependency", codes)
+            self.assertNotIn("flet-app-path", codes)
+            self.assertNotIn("flet-app-module", codes)
+
+    def test_reports_invalid_python_instead_of_skipping_it(self) -> None:
+        findings = self.findings_for_source(source="def broken(:\n")
+        self.assertIn("invalid-python", findings)
+
+    def test_accepts_keyword_only_definitions_and_real_receivers(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+def function(*, value):
+    return value
+
+class Example:
+    def method(self, *, value):
+        return value
+
+    @classmethod
+    def create(cls, *, value):
+        return value
+
+    def __new__(cls, *, value):
+        return super().__new__(cls)
+"""
+        )
+        self.assertFalse(
+            set(findings) & {"keyword-only-definition", "keyword-only-lambda"}
+        )
+
+    def test_rejects_false_receivers_variadics_and_lambdas(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+def top_level(self):
+    return self
+
+class Example:
+    @staticmethod
+    def static(cls):
+        return cls
+
+    @custom
+    @classmethod
+    def decorated(cls):
+        return cls
+
+def variadic(*args):
+    return args
+
+callable_value = lambda value: value
+"""
+        )
+        self.assertIn("keyword-only-definition", findings)
+        self.assertIn("keyword-only-lambda", findings)
+
+    def test_rejects_custom_decorators_using_trusted_names(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+from custom import override
+
+class Example:
+    @override
+    def method(self):
+        return None
+"""
+        )
+        self.assertIn("keyword-only-definition", findings)
+
+    def test_rejects_class_local_shadowing_of_a_trusted_decorator(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+class Example:
+    property = external_decorator
+
+    @property
+    def method(self):
+        return None
+"""
+        )
+        self.assertIn("keyword-only-definition", findings)
+
+    def test_nested_import_cannot_reclassify_a_custom_decorator(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+from custom import override
+
+class Example:
+    @override
+    def method(self):
+        return None
+
+def unrelated(*, value):
+    from typing import override
+    return override(value)
+"""
+        )
+        self.assertIn("keyword-only-definition", findings)
+
+    def test_rejects_assignment_aliases_for_standard_constructors(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+from dataclasses import dataclass
+
+alias = dataclass
+
+@alias
+class Record:
+    value: int
+"""
+        )
+        self.assertIn("keyword-only-callable-alias", findings)
+
+    def test_accepts_only_a_real_same_line_external_exception(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+def string_marker(value="# keyword-only-exception: fake callback ABI"):
+    return value
+
+def external(value):  # keyword-only-exception: framework callback ABI
+    return value
+"""
+        )
+        self.assertIn("keyword-only-definition", findings)
+        self.assertEqual(
+            sum(finding == "keyword-only-definition" for finding in findings),
+            1,
+        )
+
+    def test_rejects_generated_positional_constructors_and_dataclass_aliases(
+        self,
+    ) -> None:
+        findings = self.findings_for_source(
+            source="""
+if True:
+    from dataclasses import dataclass as dc
+    from dataclasses import field as dc_field
+from typing import NamedTuple as NT
+from collections import namedtuple as nt
+from dataclasses import make_dataclass as make_dc
+
+@dc
+class Record:
+    value: int = dc_field(kw_only=False)
+
+class TupleRecord(NT):
+    value: int
+
+FunctionalRecord = nt("FunctionalRecord", ["value"])
+DynamicRecord = make_dc("DynamicRecord", [("value", int)])
+"""
+        )
+        self.assertIn("keyword-only-dataclass", findings)
+        self.assertIn("keyword-only-dataclass-field", findings)
+        self.assertIn("keyword-only-generated-constructor", findings)
+
+    def test_accepts_direct_keyword_only_dataclass_field(self) -> None:
+        findings = self.findings_for_source(
+            source="""
+from dataclasses import dataclass, field
+
+@dataclass(kw_only=True)
+class Record:
+    value: int = field(kw_only=True)
+"""
+        )
+        self.assertFalse(
+            set(findings)
+            & {
+                "keyword-only-callable-alias",
+                "keyword-only-dataclass",
+                "keyword-only-dataclass-field",
+            }
+        )
+
+    def test_rejects_all_positional_rule_suppression_routes(self) -> None:
+        cases = {
+            "ignore-all": 'ignore = ["ALL"]',
+            "extend-ignore-parent": 'extend-ignore = ["PLR"]',
+            "per-file-ignore": '[tool.ruff.lint.per-file-ignores]\n"*.py" = ["PL"]',
+            "extend-per-file-ignore": (
+                '[tool.ruff.lint.extend-per-file-ignores]\n"*.py" = ["PLR0917"]'
+            ),
+        }
+        for name, suppression in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                pyproject = root / "pyproject.toml"
+                pyproject.write_text(
+                    f"""
+[project]
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[dependency-groups]
+dev = ["mypy", "pytest", "pytest-cov", "ruff"]
+
+[tool.uv]
+exclude-newer = "P7D"
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = [
+    "ANN", "ASYNC", "B", "C90", "E", "F", "FBT", "I", "PL", "PLR0917",
+    "PT", "RUF", "S", "TRY", "UP", "W",
+]
+{suppression}
+
+[tool.ruff.lint.pylint]
+max-positional-args = 0
+
+[tool.mypy]
+strict = true
+warn_unreachable = true
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-branch --cov-fail-under=100"
+
+[tool.coverage.report]
+fail_under = 100
+
+[tool.coverage.run]
+branch = true
+""",
+                    encoding="utf-8",
+                )
+                checker = Checker(root)
+                checker._check_pyproject(pyproject)
+                self.assertIn(
+                    "ruff-positional-arguments-suppression",
+                    {finding.code for finding in checker.findings},
+                )
+
+    def test_scans_source_build_package_but_skips_nested_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            files = {
+                "src/package/__init__.py": "",
+                "src/package/build/module.py": "def checked(value):\n    return value\n",
+                "examples/demo/.venv/bad.py": "def skipped(value):\n    return value\n",
+                "tools/demo/build/bad.py": "def skipped(value):\n    return value\n",
+            }
+            for relative, source in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+            checker = Checker(root)
+            checker._check_python_layout()
+            keyword_paths = {
+                finding.path
+                for finding in checker.findings
+                if finding.code == "keyword-only-definition"
+            }
+            self.assertEqual(keyword_paths, {"src/package/build/module.py:1"})
+
+    def test_rejects_explicit_ruff_source_exclusions(self) -> None:
+        for key, lint_exclude in (
+            ("exclude", ""),
+            ("extend-exclude", ""),
+            ("", 'exclude = ["src/**"]'),
+        ):
+            with (
+                self.subTest(key=key or "lint.exclude"),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                pyproject = root / "pyproject.toml"
+                pyproject.write_text(
+                    f"""
+[project]
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[dependency-groups]
+dev = ["mypy", "pytest", "pytest-cov", "ruff"]
+
+[tool.uv]
+exclude-newer = "P7D"
+
+[tool.ruff]
+{f'{key} = ["src/**"]' if key else ""}
+
+[tool.ruff.lint]
+{lint_exclude}
+preview = true
+explicit-preview-rules = true
+select = [
+    "ANN", "ASYNC", "B", "C90", "E", "F", "FBT", "I", "PL", "PLR0917",
+    "PT", "RUF", "S", "TRY", "UP", "W",
+]
+
+[tool.ruff.lint.pylint]
+max-positional-args = 0
+
+[tool.mypy]
+strict = true
+warn_unreachable = true
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-branch --cov-fail-under=100"
+
+[tool.coverage.report]
+fail_under = 100
+
+[tool.coverage.run]
+branch = true
+""",
+                    encoding="utf-8",
+                )
+                checker = Checker(root)
+                checker._check_pyproject(pyproject)
+                self.assertIn(
+                    "ruff-owned-source-exclusion",
+                    {finding.code for finding in checker.findings},
+                )
+
+    def test_accepts_generated_agent_skill_exclusion(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pyproject = root / "pyproject.toml"
+            pyproject.write_text(
+                """
+[project]
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[dependency-groups]
+dev = ["mypy", "pytest", "pytest-cov", "ruff"]
+
+[tool.uv]
+exclude-newer = "P7D"
+
+[tool.ruff]
+extend-exclude = [".agents/skills/**"]
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = [
+    "ANN", "ASYNC", "B", "C90", "E", "F", "FBT", "I", "PL", "PLR0917",
+    "PT", "RUF", "S", "TRY", "UP", "W",
+]
+
+[tool.ruff.lint.pylint]
+max-positional-args = 0
+
+[tool.mypy]
+strict = true
+warn_unreachable = true
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-branch --cov-fail-under=100"
+
+[tool.coverage.report]
+fail_under = 100
+
+[tool.coverage.run]
+branch = true
+""",
+                encoding="utf-8",
+            )
+            checker = Checker(root)
+            checker._check_pyproject(pyproject)
+            self.assertNotIn(
+                "ruff-owned-source-exclusion",
+                {finding.code for finding in checker.findings},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/python-quality-check/scripts/test_inspect_distribution.py
+++ b/.agents/skills/python-quality-check/scripts/test_inspect_distribution.py
@@ -1,0 +1,56 @@
+"""Regression tests for safe distribution archive inspection."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from inspect_distribution import inspect
+
+
+class DistributionInspectionTests(unittest.TestCase):
+    """Exercise safe path, type, and mode checks."""
+
+    def test_accepts_regular_wheel_members(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / "example-1.0-py3-none-any.whl"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("example/__init__.py", "")
+                bundle.writestr("example-1.0.dist-info/METADATA", "Name: example\n")
+            result = inspect(archive)
+            self.assertEqual((), result.findings)
+            self.assertEqual(2, result.members)
+            self.assertEqual(64, len(result.sha256))
+
+    def test_rejects_wheel_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / "example-1.0-py3-none-any.whl"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("../outside.py", "")
+            codes = {finding.code for finding in inspect(archive).findings}
+            self.assertIn("unsafe-path", codes)
+
+    def test_rejects_sdist_link_and_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / "example-1.0.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                executable = tarfile.TarInfo("example-1.0/run.py")
+                executable.mode = 0o755
+                payload = b"print('ok')\n"
+                executable.size = len(payload)
+                bundle.addfile(executable, io.BytesIO(payload))
+                link = tarfile.TarInfo("example-1.0/link")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "run.py"
+                bundle.addfile(link)
+            codes = {finding.code for finding in inspect(archive).findings}
+            self.assertIn("unexpected-executable", codes)
+            self.assertIn("special-file", codes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,7 @@ that are present in that checkout.
 - Source: [aoirint/skills](https://github.com/aoirint/skills), selected from
   `.apm/skills/`
 - Pinned commit:
-  [`8c671f524fb5df6b9def895f8b60e9a359b07644`](https://github.com/aoirint/skills/tree/8c671f524fb5df6b9def895f8b60e9a359b07644)
-- Deployed paths: `.agents/skills/{changelog-workflow,code-quality-check,commit-message-quality-check,git-worktree-workflow,github-actions-quality-check,gitignore-workflow,issue-quality-check,prose-quality-check,pull-request-quality-check,release-note-workflow,security-check,skill-quality-check}/`
-- License: [MIT](https://github.com/aoirint/skills/blob/8c671f524fb5df6b9def895f8b60e9a359b07644/LICENSE)
+  [`329572438060c1b0c34882b2c3a8e388ae30cd1a`](https://github.com/aoirint/skills/tree/329572438060c1b0c34882b2c3a8e388ae30cd1a)
+- Deployed paths: `.agents/skills/{apm-usage,changelog-workflow,code-quality-check,commit-message-quality-check,docker-quality-check,git-worktree-workflow,github-workflow,gitignore-workflow,prose-quality-check,python-quality-check,release-note-workflow,security-check}/`
+- License: [MIT](https://github.com/aoirint/skills/blob/329572438060c1b0c34882b2c3a8e388ae30cd1a/LICENSE)
+- Copyright: Copyright (c) 2026 aoirint

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,15 +1,24 @@
 lockfile_version: '1'
-generated_at: '2026-07-26T02:33:08.265863+00:00'
+generated_at: '2026-08-11T00:40:49.030563+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: aoirint/skills
   name: skills
   host: github.com
-  resolved_commit: 4361f1c00e419199803f6f88a760654f486f3ae4
-  resolved_ref: 4361f1c00e419199803f6f88a760654f486f3ae4
+  resolved_commit: 329572438060c1b0c34882b2c3a8e388ae30cd1a
+  resolved_ref: 329572438060c1b0c34882b2c3a8e388ae30cd1a
   version: 0.0.0
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apm-usage
+  - .agents/skills/apm-usage/README.md
+  - .agents/skills/apm-usage/SKILL.md
+  - .agents/skills/apm-usage/agents/openai.yaml
+  - .agents/skills/apm-usage/assets/check-apm-project/action.yml
+  - .agents/skills/apm-usage/references/apm-bootstrap.json
+  - .agents/skills/apm-usage/references/ci-guards.md
+  - .agents/skills/apm-usage/scripts/propose_bootstrap_update.py
+  - .agents/skills/apm-usage/scripts/propose_bootstrap_update.py.lock
   - .agents/skills/changelog-workflow
   - .agents/skills/changelog-workflow/README.md
   - .agents/skills/changelog-workflow/SKILL.md
@@ -22,10 +31,22 @@ dependencies:
   - .agents/skills/commit-message-quality-check/README.md
   - .agents/skills/commit-message-quality-check/SKILL.md
   - .agents/skills/commit-message-quality-check/agents/openai.yaml
+  - .agents/skills/docker-quality-check
+  - .agents/skills/docker-quality-check/README.md
+  - .agents/skills/docker-quality-check/SKILL.md
+  - .agents/skills/docker-quality-check/agents/openai.yaml
   - .agents/skills/git-worktree-workflow
   - .agents/skills/git-worktree-workflow/README.md
   - .agents/skills/git-worktree-workflow/SKILL.md
   - .agents/skills/git-worktree-workflow/agents/openai.yaml
+  - .agents/skills/github-workflow
+  - .agents/skills/github-workflow/README.md
+  - .agents/skills/github-workflow/SKILL.md
+  - .agents/skills/github-workflow/agents/openai.yaml
+  - .agents/skills/github-workflow/references/fallback-pr-body.md
+  - .agents/skills/github-workflow/references/repository-enforcement.md
+  - .agents/skills/github-workflow/references/runner-selection.md
+  - .agents/skills/github-workflow/scripts/check_llm_disclosure.py
   - .agents/skills/gitignore-workflow
   - .agents/skills/gitignore-workflow/README.md
   - .agents/skills/gitignore-workflow/SKILL.md
@@ -34,6 +55,18 @@ dependencies:
   - .agents/skills/prose-quality-check/README.md
   - .agents/skills/prose-quality-check/SKILL.md
   - .agents/skills/prose-quality-check/agents/openai.yaml
+  - .agents/skills/python-quality-check
+  - .agents/skills/python-quality-check/README.md
+  - .agents/skills/python-quality-check/SKILL.md
+  - .agents/skills/python-quality-check/agents/openai.yaml
+  - .agents/skills/python-quality-check/references/ci-and-distribution.md
+  - .agents/skills/python-quality-check/references/tooling-and-testing.md
+  - .agents/skills/python-quality-check/scripts/check_project.py
+  - .agents/skills/python-quality-check/scripts/check_project.py.lock
+  - .agents/skills/python-quality-check/scripts/inspect_distribution.py
+  - .agents/skills/python-quality-check/scripts/inspect_distribution.py.lock
+  - .agents/skills/python-quality-check/scripts/test_check_project.py
+  - .agents/skills/python-quality-check/scripts/test_inspect_distribution.py
   - .agents/skills/release-note-workflow
   - .agents/skills/release-note-workflow/README.md
   - .agents/skills/release-note-workflow/SKILL.md
@@ -45,6 +78,14 @@ dependencies:
   - .agents/skills/security-check/references/artifact-inspection.md
   - .agents/skills/security-check/references/external-code-execution.md
   deployed_file_hashes:
+    .agents/skills/apm-usage/README.md: sha256:70351aaebf54291433dfcff86280e87edc757ff4e93e506aa1e8f06a0b913f06
+    .agents/skills/apm-usage/SKILL.md: sha256:82bfde7980c17b69f043b62cb5669a42b1e65386f4a8476a224617285f33653e
+    .agents/skills/apm-usage/agents/openai.yaml: sha256:931ed250f3abe81dcad27da5b668d7546cd65f528cd37de754dee4c9df1905e0
+    .agents/skills/apm-usage/assets/check-apm-project/action.yml: sha256:108bc5e9964026880fb49086728f8458b16174f33636dea79276bd286505bbd4
+    .agents/skills/apm-usage/references/apm-bootstrap.json: sha256:f3b8921d2db8d6bfad9088657895b126ebd8d87b92133bd65331be4a8a0a515e
+    .agents/skills/apm-usage/references/ci-guards.md: sha256:7898244519895206b90713bdeb23d7bc8ba54437f8205944cdce98acf12fe1d1
+    .agents/skills/apm-usage/scripts/propose_bootstrap_update.py: sha256:9d7d3a4292a9ad4a833f970a51cce0202f3850503d39e410c1d2fccad5eb0b58
+    .agents/skills/apm-usage/scripts/propose_bootstrap_update.py.lock: sha256:016afc221516f1724533f1623ec77ef8a9a80c06a1ffae431f32f5e063e59986
     .agents/skills/changelog-workflow/README.md: sha256:7ef8167d26522d95f62b9f11d752487d62b6bfdae05850315189fbe2a19fed83
     .agents/skills/changelog-workflow/SKILL.md: sha256:8d9de8e0e3c31c4a2c176a0d14e3f1a45daf3db364ede7dd86983c8c3f571f54
     .agents/skills/changelog-workflow/agents/openai.yaml: sha256:6264e6dbd0433ab63370e15033ecb94da8dd131c4edcb1d3f2b9abdeb4f680f1
@@ -54,15 +95,36 @@ dependencies:
     .agents/skills/commit-message-quality-check/README.md: sha256:c23949080d05f47cce728410ca3190225397aa41ac2015c6f02ee478ec412a24
     .agents/skills/commit-message-quality-check/SKILL.md: sha256:db272bb7467bcb6a6c3d837dec60a34f7081c135fcd40a9e00cf4a84e29ffabe
     .agents/skills/commit-message-quality-check/agents/openai.yaml: sha256:faffd948a0989dcfc87dcd3b0580c4a7003d01ef436e66dab9f280df57de652c
+    .agents/skills/docker-quality-check/README.md: sha256:912a73d3de06babc6eed1ecdaf275139ae465797083dc5427affb54d00c57bf0
+    .agents/skills/docker-quality-check/SKILL.md: sha256:1dfe7b749211884c5ffcc9670406330c9c89b91e9147f9507c3e168270828b4d
+    .agents/skills/docker-quality-check/agents/openai.yaml: sha256:8abdaaa5a0458e86821080f50a2dfc34374c5c673a6c257fa351a2a96a16d064
     .agents/skills/git-worktree-workflow/README.md: sha256:fa6483b5919a01b84fa0d6ffcbaae20b84ed3807e18029e8807e61b0ee4f9de9
     .agents/skills/git-worktree-workflow/SKILL.md: sha256:67e2474b9878cc6cb209ae30b19c233f65969abe5b5d543f0c9a16e46f1d40d2
     .agents/skills/git-worktree-workflow/agents/openai.yaml: sha256:3eb9da73e7a041e77d82f0d5c3a8c67e914575cff8651b71d077db30fe3da99a
+    .agents/skills/github-workflow/README.md: sha256:22305baeccffab98041f4783195fc5b7804dc7429d7974cd8c8571053152fdba
+    .agents/skills/github-workflow/SKILL.md: sha256:29d9a78a6c2cf98fb3c102c4b4f402f96b90412a72656588bcf6ebfc4224ad09
+    .agents/skills/github-workflow/agents/openai.yaml: sha256:615f3c2c18824bf08ec32a4027901b89259e6c42255c736e86b206caf1bf1a7c
+    .agents/skills/github-workflow/references/fallback-pr-body.md: sha256:b98239e7d4cdddd8e267ab155f4e4c38fcc514526d9a32f13fcd5b21a1c07eb2
+    .agents/skills/github-workflow/references/repository-enforcement.md: sha256:92d546edb39d63bbee8cf806eecb7766aeebf349ab0986a673a0df9ba753dbd1
+    .agents/skills/github-workflow/references/runner-selection.md: sha256:6e9929a316ba9efbf6171366de0d1a3c976aee73d22c26b2d1ec33017af6f164
+    .agents/skills/github-workflow/scripts/check_llm_disclosure.py: sha256:bc9c5cbd8efa77095eac42e53da714ed8dff86fa3b0e7870fc3e7eca1ca36e20
     .agents/skills/gitignore-workflow/README.md: sha256:0de188ebcdd40ea1aec701410e1c2182049b66bc4ec4d83a3bf55685b4267d47
     .agents/skills/gitignore-workflow/SKILL.md: sha256:2ef38f42e418c10e0ba7632e3ba37614df97044dfa8847ad1338e6c4c896c089
     .agents/skills/gitignore-workflow/agents/openai.yaml: sha256:f6a9b176003028588ff4c1d9ee4e23c625892d00b65086bf4b6b26a3f896030d
     .agents/skills/prose-quality-check/README.md: sha256:8e4d9f8f8fdfba1cf7fe71fa88cac6baffa0d3c7616f744c0e3b1add102be5e7
     .agents/skills/prose-quality-check/SKILL.md: sha256:9ec45813d04382e04a3b504fd187e4151fc5198352564bd0bcb064f4eaf9a702
     .agents/skills/prose-quality-check/agents/openai.yaml: sha256:b83e0a5d151e6e20df6f7d97f268955c6abfd105d53820f6baad0de8403fc062
+    .agents/skills/python-quality-check/README.md: sha256:20a23003a24a8caf2f03dd5a06bed99c81cf93ab53fe5a196c6a67ab59c53b0e
+    .agents/skills/python-quality-check/SKILL.md: sha256:76c8c0d01064417e4d8e709a22f2b60b5ec62a57d9c641029e95c76a8b39b79d
+    .agents/skills/python-quality-check/agents/openai.yaml: sha256:f0b4ad3807e177becec02271314fb32c1ec8d5a7682725ddd4a611a5381084d1
+    .agents/skills/python-quality-check/references/ci-and-distribution.md: sha256:0f97408fd9f98dc43d468064e4f601eb26ce10e01939a9cc8ba3227ca97b6947
+    .agents/skills/python-quality-check/references/tooling-and-testing.md: sha256:61ff7e27674d45949003576bef5bdb0c225172f69ba1d6c0a3129feabc42c23a
+    .agents/skills/python-quality-check/scripts/check_project.py: sha256:8175b500198399a2ce8b79b4fc8d1902f791d163a0d6dfd35b5ce56b41c5ccc5
+    .agents/skills/python-quality-check/scripts/check_project.py.lock: sha256:76042d39ffdbb675188966b4fc41d312b0ec9374a7aa438d4f5e919adcf04c07
+    .agents/skills/python-quality-check/scripts/inspect_distribution.py: sha256:86cc60199cf85c6eab39f648c9892963fbfd2ec6d913106119b0eb679eca6849
+    .agents/skills/python-quality-check/scripts/inspect_distribution.py.lock: sha256:76042d39ffdbb675188966b4fc41d312b0ec9374a7aa438d4f5e919adcf04c07
+    .agents/skills/python-quality-check/scripts/test_check_project.py: sha256:3f11ecf64d5febb40c3401cd1af77fdc979c273ed3e58000c5de15cc75bf4f89
+    .agents/skills/python-quality-check/scripts/test_inspect_distribution.py: sha256:71758c1bb5e05991d8965a323f41e7c25aba529e777a9340d38c10f433392263
     .agents/skills/release-note-workflow/README.md: sha256:f13446e75a1c77495c4d55476ba8ca919aa3181e0864feb7a668a20a5cdf964b
     .agents/skills/release-note-workflow/SKILL.md: sha256:518296cb00d1ef181785ea8abd0150b9704b5cdd05a48fc0390284c548ef421c
     .agents/skills/release-note-workflow/agents/openai.yaml: sha256:30cfe7d4520783cfc8c72f5f81cc3e7a5708a5827e691f0003a665d89558fda0
@@ -71,21 +133,103 @@ dependencies:
     .agents/skills/security-check/agents/openai.yaml: sha256:87edf0cc1e8717194d0c536f2d5ac0cc1ac9ec04402311d34e953d2e2b23fa19
     .agents/skills/security-check/references/artifact-inspection.md: sha256:9842555f4789e77e6cf3d22b000116497207ecf6fa5587f2b1fe0dc20e7dffda
     .agents/skills/security-check/references/external-code-execution.md: sha256:87ca817baa02ef6b955e5878f0cd79c875abdb0be6e0177cfce158968e628bc3
-  content_hash: sha256:9af2aba371779ec675b76fde4a23eef4be77607b9c4968030401d2cbe3bdaae8
+  content_hash: sha256:9a62dc48d3bb2f41ba02046b5df84457d1bd54d21526bdc55d5cbac6ee943972
   skill_subset:
+  - apm-usage
   - changelog-workflow
   - code-quality-check
   - commit-message-quality-check
+  - docker-quality-check
   - git-worktree-workflow
-  - github-actions-quality-check
+  - github-workflow
   - gitignore-workflow
-  - issue-quality-check
   - prose-quality-check
-  - pull-request-quality-check
+  - python-quality-check
   - release-note-workflow
   - security-check
   declared_license: MIT
 deployments:
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/README.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:70351aaebf54291433dfcff86280e87edc757ff4e93e506aa1e8f06a0b913f06
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:82bfde7980c17b69f043b62cb5669a42b1e65386f4a8476a224617285f33653e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:931ed250f3abe81dcad27da5b668d7546cd65f528cd37de754dee4c9df1905e0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/assets/check-apm-project/action.yml
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:108bc5e9964026880fb49086728f8458b16174f33636dea79276bd286505bbd4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/references/apm-bootstrap.json
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:f3b8921d2db8d6bfad9088657895b126ebd8d87b92133bd65331be4a8a0a515e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/references/ci-guards.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:7898244519895206b90713bdeb23d7bc8ba54437f8205944cdce98acf12fe1d1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/scripts/propose_bootstrap_update.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:9d7d3a4292a9ad4a833f970a51cce0202f3850503d39e410c1d2fccad5eb0b58
+- kind: project-relative
+  target: codex
+  value: .agents/skills/apm-usage/scripts/propose_bootstrap_update.py.lock
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:016afc221516f1724533f1623ec77ef8a9a80c06a1ffae431f32f5e063e59986
 - kind: project-relative
   target: codex
   value: .agents/skills/changelog-workflow
@@ -196,6 +340,42 @@ deployments:
   content_hash: sha256:faffd948a0989dcfc87dcd3b0580c4a7003d01ef436e66dab9f280df57de652c
 - kind: project-relative
   target: codex
+  value: .agents/skills/docker-quality-check
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/docker-quality-check/README.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:912a73d3de06babc6eed1ecdaf275139ae465797083dc5427affb54d00c57bf0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/docker-quality-check/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:1dfe7b749211884c5ffcc9670406330c9c89b91e9147f9507c3e168270828b4d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/docker-quality-check/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:8abdaaa5a0458e86821080f50a2dfc34374c5c673a6c257fa351a2a96a16d064
+- kind: project-relative
+  target: codex
   value: .agents/skills/git-worktree-workflow
   runtime: null
   scope: project
@@ -230,6 +410,78 @@ deployments:
   - aoirint/skills
   active_owner: aoirint/skills
   content_hash: sha256:3eb9da73e7a041e77d82f0d5c3a8c67e914575cff8651b71d077db30fe3da99a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/README.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:22305baeccffab98041f4783195fc5b7804dc7429d7974cd8c8571053152fdba
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:29d9a78a6c2cf98fb3c102c4b4f402f96b90412a72656588bcf6ebfc4224ad09
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:615f3c2c18824bf08ec32a4027901b89259e6c42255c736e86b206caf1bf1a7c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/references/fallback-pr-body.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:b98239e7d4cdddd8e267ab155f4e4c38fcc514526d9a32f13fcd5b21a1c07eb2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/references/repository-enforcement.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:92d546edb39d63bbee8cf806eecb7766aeebf349ab0986a673a0df9ba753dbd1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/references/runner-selection.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:6e9929a316ba9efbf6171366de0d1a3c976aee73d22c26b2d1ec33017af6f164
+- kind: project-relative
+  target: codex
+  value: .agents/skills/github-workflow/scripts/check_llm_disclosure.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:bc9c5cbd8efa77095eac42e53da714ed8dff86fa3b0e7870fc3e7eca1ca36e20
 - kind: project-relative
   target: codex
   value: .agents/skills/gitignore-workflow
@@ -302,6 +554,114 @@ deployments:
   - aoirint/skills
   active_owner: aoirint/skills
   content_hash: sha256:b83e0a5d151e6e20df6f7d97f268955c6abfd105d53820f6baad0de8403fc062
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/README.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:20a23003a24a8caf2f03dd5a06bed99c81cf93ab53fe5a196c6a67ab59c53b0e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:76c8c0d01064417e4d8e709a22f2b60b5ec62a57d9c641029e95c76a8b39b79d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:f0b4ad3807e177becec02271314fb32c1ec8d5a7682725ddd4a611a5381084d1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/references/ci-and-distribution.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:0f97408fd9f98dc43d468064e4f601eb26ce10e01939a9cc8ba3227ca97b6947
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/references/tooling-and-testing.md
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:61ff7e27674d45949003576bef5bdb0c225172f69ba1d6c0a3129feabc42c23a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/check_project.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:8175b500198399a2ce8b79b4fc8d1902f791d163a0d6dfd35b5ce56b41c5ccc5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/check_project.py.lock
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:76042d39ffdbb675188966b4fc41d312b0ec9374a7aa438d4f5e919adcf04c07
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/inspect_distribution.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:86cc60199cf85c6eab39f648c9892963fbfd2ec6d913106119b0eb679eca6849
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/inspect_distribution.py.lock
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:76042d39ffdbb675188966b4fc41d312b0ec9374a7aa438d4f5e919adcf04c07
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/test_check_project.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:3f11ecf64d5febb40c3401cd1af77fdc979c273ed3e58000c5de15cc75bf4f89
+- kind: project-relative
+  target: codex
+  value: .agents/skills/python-quality-check/scripts/test_inspect_distribution.py
+  runtime: null
+  scope: project
+  owners:
+  - aoirint/skills
+  active_owner: aoirint/skills
+  content_hash: sha256:71758c1bb5e05991d8965a323f41e7c25aba529e777a9340d38c10f433392263
 - kind: project-relative
   target: codex
   value: .agents/skills/release-note-workflow

--- a/apm.yml
+++ b/apm.yml
@@ -8,17 +8,18 @@ targets:
 dependencies:
   apm:
     - git: aoirint/skills
-      ref: 4361f1c00e419199803f6f88a760654f486f3ae4
+      ref: 329572438060c1b0c34882b2c3a8e388ae30cd1a
       skills:
+        - apm-usage
         - changelog-workflow
         - code-quality-check
         - commit-message-quality-check
+        - docker-quality-check
         - git-worktree-workflow
-        - github-actions-quality-check
+        - github-workflow
         - gitignore-workflow
-        - issue-quality-check
         - prose-quality-check
-        - pull-request-quality-check
+        - python-quality-check
         - release-note-workflow
         - security-check
   mcp: []


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Pin `aoirint/skills` to `329572438060c1b0c34882b2c3a8e388ae30cd1a`.
- Replace the retired GitHub-specific Skill names with `github-workflow`.
- Deploy the APM, Docker, GitHub, and Python quality Skills needed by this repository.
- Regenerate the APM deployment ledger and update the third-party notice.

## Related Issues

None.

## Notes for reviewers

The selected upstream commit was authored on 2026-08-10 and has not completed the normal seven-day cooldown. The maintainer waiver in `AGENTS.md` is applied specifically to `aoirint/skills@329572438060c1b0c34882b2c3a8e388ae30cd1a`. The waiver covers only the cooldown gate; the source diff, provenance, MIT license, bundled scripts, immutable pin, lock hashes, and deployed output were still reviewed.

The lockfile was regenerated from scratch with APM CLI 0.26.0 because an incremental lock retained the old deployment ledger.

### Proposed merge attribution

- Codex
  - Resolved trailer: `Co-authored-by: Codex <noreply@openai.com>`
  - Basis: Material implementation and verification assistance for commit `003d0b2fa70db90ed778559d05f5455be9e702ad`.
  - Status: Included

The PR creator is the primary Git author and is not duplicated as a co-author.

### AI disclosure

Codex selected the repository-relevant Skill set, reviewed the upstream source and supply-chain metadata, regenerated the APM deployment, and ran the verification described below. The maintainer retains responsibility for the cooldown waiver already recorded in `AGENTS.md`.

## Testing

### Automated checks

- `/usr/local/bin/apm install --frozen` — passed; 12 Skills deployed.
- `/usr/local/bin/apm audit --ci` — passed; all 10 checks passed and cache-only replay found no drift.
- `python3 -m compileall -q` for bundled Skill scripts — passed.
- `python3 -m unittest discover -s .agents/skills/python-quality-check/scripts -p 'test_*.py'` — passed; 18 tests.
- `git diff --cached --check` and `git diff --check HEAD^ HEAD` — passed.

### AI-assisted inspections

- Request: Review provenance, license, selected capabilities, deployment integrity, Skill metadata, and commit attribution.
  - AI-assisted result: The exact upstream SHA and MIT notice are recorded; all 12 deployed directories match upstream `.apm/skills` byte-for-byte; every Skill has aligned directory/frontmatter naming and required `agents/openai.yaml` interface fields; the stored commit contains the expected Codex trailer exactly once.

### Manual checks

None.
