### PR TITLE
build: update agent skills

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ that are present in that checkout.
 - Source: [aoirint/skills](https://github.com/aoirint/skills), selected from
   `.apm/skills/`
 - Pinned commit:
-  [`6a1e6431bbaed762f55783c3dcd7dc4b07736596`](https://github.com/aoirint/skills/tree/6a1e6431bbaed762f55783c3dcd7dc4b07736596)
+  [`2c77fb8583c437c7e47cd293f4bc703f410b9be0`](https://github.com/aoirint/skills/tree/2c77fb8583c437c7e47cd293f4bc703f410b9be0)
 - Deployed paths: `.agents/skills/{apm-workflow,changelog-workflow,code-quality-check,commit-message-quality-check,docker-quality-check,git-worktree-workflow,github-workflow,gitignore-workflow,prose-quality-check,python-quality-check,release-note-workflow,security-check}/`
-- License: [MIT](https://github.com/aoirint/skills/blob/6a1e6431bbaed762f55783c3dcd7dc4b07736596/LICENSE)
+- License: [MIT](https://github.com/aoirint/skills/blob/2c77fb8583c437c7e47cd293f4bc703f410b9be0/LICENSE)
 - Copyright: Copyright (c) 2026 aoirint

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,12 +1,12 @@
 lockfile_version: '1'
-generated_at: '2026-08-11T07:12:25.413331+00:00'
+generated_at: '2026-08-11T08:23:16.372832+00:00'
 apm_version: 0.27.0
 dependencies:
 - repo_url: aoirint/skills
   name: skills
   host: github.com
-  resolved_commit: 6a1e6431bbaed762f55783c3dcd7dc4b07736596
-  resolved_ref: 6a1e6431bbaed762f55783c3dcd7dc4b07736596
+  resolved_commit: 2c77fb8583c437c7e47cd293f4bc703f410b9be0
+  resolved_ref: 2c77fb8583c437c7e47cd293f4bc703f410b9be0
   version: 0.0.0
   package_type: apm_package
   deployed_files:
@@ -141,7 +141,7 @@ dependencies:
     .agents/skills/security-check/agents/openai.yaml: sha256:87edf0cc1e8717194d0c536f2d5ac0cc1ac9ec04402311d34e953d2e2b23fa19
     .agents/skills/security-check/references/artifact-inspection.md: sha256:9842555f4789e77e6cf3d22b000116497207ecf6fa5587f2b1fe0dc20e7dffda
     .agents/skills/security-check/references/external-code-execution.md: sha256:87ca817baa02ef6b955e5878f0cd79c875abdb0be6e0177cfce158968e628bc3
-  content_hash: sha256:ac27952ee585df0cc8fdfb53d02e4681405ca7b5eebb80f2c2d1707342adaeef
+  content_hash: sha256:110695f3f8ab158f51ef37eb143f131dfed711dfab670460a377d517199bd723
   skill_subset:
   - apm-workflow
   - changelog-workflow

--- a/apm.yml
+++ b/apm.yml
@@ -8,7 +8,7 @@ targets:
 dependencies:
   apm:
     - git: aoirint/skills
-      ref: 6a1e6431bbaed762f55783c3dcd7dc4b07736596
+      ref: 2c77fb8583c437c7e47cd293f4bc703f410b9be0
       skills:
         - apm-workflow
         - changelog-workflow


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- update the pinned `aoirint/skills` source to include the latest validated BepInEx release-plan guidance
- refresh the APM lockfile, deployment output when affected, and provenance metadata
- keep the existing repository-specific workflow and quality contracts unchanged

Canonical source: [aoirint/skills pull request #94](https://github.com/aoirint/skills/pull/94), merged as [`2c77fb8583c437c7e47cd293f4bc703f410b9be0`](https://github.com/aoirint/skills/commit/2c77fb8583c437c7e47cd293f4bc703f410b9be0).

## Verification

- `apm lock`
- `apm install --frozen`
- `apm audit --ci`
- `git diff --check`
- confirmed the previous Skill source SHA is absent from the updated dependency metadata

## Attribution

- Included: `Co-authored-by: Codex <noreply@openai.com>`
