### PR TITLE
build(apm): roll out reviewed APM 0.28.0 defaults

### DIFF
--- a/.agents/skills/apm-workflow/references/apm-bootstrap.json
+++ b/.agents/skills/apm-workflow/references/apm-bootstrap.json
@@ -1,40 +1,40 @@
 {
-  "version": "v0.27.0",
-  "published_at": "2026-08-02T20:11:22Z",
+  "version": "v0.28.0",
+  "published_at": "2026-08-06T09:29:03Z",
   "cooldown_days": 7,
-  "eligible_on": "2026-08-09T20:11:22Z",
-  "release_url": "https://github.com/microsoft/apm/releases/tag/v0.27.0",
+  "eligible_on": "2026-08-13T09:29:03Z",
+  "release_url": "https://github.com/microsoft/apm/releases/tag/v0.28.0",
   "download_url_template": "https://github.com/microsoft/apm/releases/download/{version}/{asset}",
   "assets": [
     {
       "platform": "macos-arm64",
       "archive": "apm-darwin-arm64.tar.gz",
       "extracted_directory": "apm-darwin-arm64",
-      "sha256": "4c68e5eaa3cfdb0b25734c316deb532835eaf3c3e2f7379a4c7c06918043a641"
+      "sha256": "9676a6e7bf2bcb3966538a7130faea14ba030baa45f678597cc3fa15c902cb0a"
     },
     {
       "platform": "macos-x86_64",
       "archive": "apm-darwin-x86_64.tar.gz",
       "extracted_directory": "apm-darwin-x86_64",
-      "sha256": "846b30055d96cbc6fa0fcf451f50d13f632b540ffdff344873a025bba607e25a"
+      "sha256": "a8397925d45edc3dd666ec80c634f09eb9e5030328288aa0b0ca13c31608f0e0"
     },
     {
       "platform": "linux-arm64",
       "archive": "apm-linux-arm64.tar.gz",
       "extracted_directory": "apm-linux-arm64",
-      "sha256": "7df6e64ca9540665367f07af0226077ba92820f6cc759c10a5ca37e038a500e4"
+      "sha256": "0b3a644d6073106d1a06623e0baa0c4d75a5ae5ffe55c30eed927bba48600119"
     },
     {
       "platform": "linux-x86_64",
       "archive": "apm-linux-x86_64.tar.gz",
       "extracted_directory": "apm-linux-x86_64",
-      "sha256": "be2d8a97ca8816636117ec26da85482d647ae3353213ea022fb1130c2dd3d3b0"
+      "sha256": "7edab3baba96658a20120fc8f3012e3223da7924937a8cbf169bf9805853b8d7"
     },
     {
       "platform": "windows-x86_64",
       "archive": "apm-windows-x86_64.zip",
       "extracted_directory": "apm-windows-x86_64",
-      "sha256": "1a7703864babee7deaab3d13b4fe50b51ea5c1ae2edb2dae46fbbab5a6cead9d"
+      "sha256": "b7085454956a8fa60aa61c062c566095bffe6bc1d6c0902f3a6657b1d1d7fc85"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,8 @@ directly.
 
 ### Approved cooldown exception
 
-Use APM CLI 0.27.0 for lock operations. Its normal seven-day cooldown was
-explicitly waived because it fixes virtual-package `config-consistency` audit
-failures. The waiver covers only the CLI release time gate.
+Use APM CLI 0.28.0 for lock operations. It is the newest reviewed release
+that satisfies the normal seven-day cooldown; using it is not an exception.
 
 A maintainer may explicitly waive the normal seven-day wait for the latest
 `aoirint/skills` main commit. Record the waiver and exact full commit SHA in

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ that are present in that checkout.
 - Source: [aoirint/skills](https://github.com/aoirint/skills), selected from
   `.apm/skills/`
 - Pinned commit:
-  [`f4aa56f4abffb1448c24c04ea4ae4463f5721d10`](https://github.com/aoirint/skills/tree/f4aa56f4abffb1448c24c04ea4ae4463f5721d10)
+  [`44b51eef2237a460a4d3bca423a675b1ffd09eda`](https://github.com/aoirint/skills/tree/44b51eef2237a460a4d3bca423a675b1ffd09eda)
 - Deployed paths: `.agents/skills/{apm-workflow,changelog-workflow,code-quality-check,commit-message-quality-check,docker-quality-check,git-worktree-workflow,github-workflow,gitignore-workflow,prose-quality-check,python-quality-check,release-note-workflow,security-check}/`
-- License: [MIT](https://github.com/aoirint/skills/blob/f4aa56f4abffb1448c24c04ea4ae4463f5721d10/LICENSE)
+- License: [MIT](https://github.com/aoirint/skills/blob/44b51eef2237a460a4d3bca423a675b1ffd09eda/LICENSE)
 - Copyright: Copyright (c) 2026 aoirint

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,12 +1,12 @@
 lockfile_version: '1'
-generated_at: '2026-08-11T15:13:25.420184+00:00'
-apm_version: 0.27.0
+generated_at: '2026-08-15T09:45:14.815466+00:00'
+apm_version: 0.28.0
 dependencies:
 - repo_url: aoirint/skills
   name: skills
   host: github.com
-  resolved_commit: f4aa56f4abffb1448c24c04ea4ae4463f5721d10
-  resolved_ref: f4aa56f4abffb1448c24c04ea4ae4463f5721d10
+  resolved_commit: 44b51eef2237a460a4d3bca423a675b1ffd09eda
+  resolved_ref: 44b51eef2237a460a4d3bca423a675b1ffd09eda
   version: 0.0.0
   package_type: apm_package
   deployed_files:
@@ -86,7 +86,7 @@ dependencies:
     .agents/skills/apm-workflow/README.md: sha256:e346edab06f5ec792cdb77edcaa8042f523af67753dc4fe72498ae1899b87c89
     .agents/skills/apm-workflow/SKILL.md: sha256:bbddd9935373713999b78e5390b3c38e0886299beeb410d6eb338d13e25154fa
     .agents/skills/apm-workflow/agents/openai.yaml: sha256:f3c083196472ec9253886b369202ddeb8eb2534fd2da9799798bae2eb33b2e55
-    .agents/skills/apm-workflow/references/apm-bootstrap.json: sha256:e0ebfd624fc79e35c5a5a305d77476860ff87019edc3afc0b37b5cd2884276b1
+    .agents/skills/apm-workflow/references/apm-bootstrap.json: sha256:ae425dc00b981c195e0664ad77b9fed8c4667a45efcdadd382e79fb572d7fc22
     .agents/skills/apm-workflow/scripts/propose_bootstrap_update.py: sha256:5c8d079ff9caa4175a971c5d231bc24d8143d47d238496cace60b1d91d8d00d8
     .agents/skills/apm-workflow/scripts/propose_bootstrap_update.py.lock: sha256:016afc221516f1724533f1623ec77ef8a9a80c06a1ffae431f32f5e063e59986
     .agents/skills/changelog-workflow/README.md: sha256:7ef8167d26522d95f62b9f11d752487d62b6bfdae05850315189fbe2a19fed83
@@ -143,7 +143,7 @@ dependencies:
     .agents/skills/security-check/references/artifact-inspection.md: sha256:9842555f4789e77e6cf3d22b000116497207ecf6fa5587f2b1fe0dc20e7dffda
     .agents/skills/security-check/references/distributed-software-licensing.md: sha256:dce7c9fbfe665eb875388ab732b63b0226a5fd4592b12a62c42b6d1372c0d025
     .agents/skills/security-check/references/external-code-execution.md: sha256:87ca817baa02ef6b955e5878f0cd79c875abdb0be6e0177cfce158968e628bc3
-  content_hash: sha256:157c9a36a0efd2a912881899bc1db19168a6c54511a7a62b106c23af0ed3d500
+  content_hash: sha256:4dd5a906943c218d3d61fad4e13de7618b61ce9643af1727db4a8f520938dd29
   skill_subset:
   - apm-workflow
   - changelog-workflow
@@ -203,7 +203,7 @@ deployments:
   owners:
   - aoirint/skills
   active_owner: aoirint/skills
-  content_hash: sha256:e0ebfd624fc79e35c5a5a305d77476860ff87019edc3afc0b37b5cd2884276b1
+  content_hash: sha256:ae425dc00b981c195e0664ad77b9fed8c4667a45efcdadd382e79fb572d7fc22
 - kind: project-relative
   target: codex
   value: .agents/skills/apm-workflow/scripts/propose_bootstrap_update.py

--- a/apm.yml
+++ b/apm.yml
@@ -8,7 +8,7 @@ targets:
 dependencies:
   apm:
     - git: aoirint/skills
-      ref: f4aa56f4abffb1448c24c04ea4ae4463f5721d10
+      ref: 44b51eef2237a460a4d3bca423a675b1ffd09eda
       skills:
         - apm-workflow
         - changelog-workflow


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

Align the repository with the [canonical APM 0.28.0 rollout](https://github.com/aoirint/skills/pull/106). Update the Agent Skills pin, regenerate the deployment ledger and deployed bootstrap manifest, refresh the third-party notice, and align local CLI guidance where present.

## Related Issues

- [Canonical rollout](https://github.com/aoirint/skills/pull/106)

## Notes for reviewers

Maintainer authorization waives only the time gate for immediately adopting the direct `aoirint/skills` dependency at full commit [`44b51eef2237a460a4d3bca423a675b1ffd09eda`](https://github.com/aoirint/skills/commit/44b51eef2237a460a4d3bca423a675b1ffd09eda). Provenance, license, dependency, and audit review remain required and were completed.

### Proposed merge attribution

- Codex
  - Resolved trailer: `Co-authored-by: Codex <noreply@openai.com>`
  - Basis: Materially implemented and verified this rollout.
  - Status: Included

### AI disclosure

Codex updated the pin and deployment metadata, regenerated the ledger, and performed the listed verification.

## Testing

### Automated checks

- `apm lock --update` from an empty ledger with APM 0.28.0
- `apm install --frozen`
- `apm audit --ci`
- `git diff --check`

### AI-assisted inspections

- Request: Verify the canonical SHA, CLI version, notice, and meaningful diff.
  - AI-assisted result: Passed. Generated line-ending-only changes were excluded from the commit.
